### PR TITLE
Add monolog as a required dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "monolog/monolog": "1.21.0",
         "php": ">=5.5",
         "psr/log": "1.0.0"
     },


### PR DESCRIPTION
We use monolog as the default logger, but weren't explicitly requiring it.