### PR TITLE
add travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+before_script:
+  - composer self-update
+  - composer update --no-interaction $COMPOSER_OPTS
+script:
+  - vendor/bin/phpunit tests --coverage-text


### PR DESCRIPTION
apologies if this request seems forward. i'm not familiar with circle CI but i know travis pretty well. i'm interested in testing the dependency ranges in the CI build and i know how to do that in travis. if there is some documentation you can point to for how to accomplish this in circle CI i would be happy to give it a try : )

add travis config to test PHP versions 5.5 to 7.1. each PHP version is tested with the minimum and maximum dependency versions which provides some certainty that our dependency ranges in the composer config are valid.

here's a sample of the build output on my fork:
https://travis-ci.org/abacaphiliac/php-client/builds/184626287