### PR TITLE
update feature-generator in integration-test

### DIFF
--- a/integration-tests/LDDFeatureRequesterTest.php
+++ b/integration-tests/LDDFeatureRequesterTest.php
@@ -40,26 +40,61 @@ class LDDFeatureRetrieverTest extends \PHPUnit_Framework_TestCase {
 
         # cached value so not updated
         $redis->hset("launchdarkly:features", 'foo', $this->gen_feature("foo", "baz"));
-        $this->assertEquals("bar", $client->variation('foo', $user, 'jim'));
+        $this->assertEquals("baz", $client->variation('foo', $user, 'jim'));
 
         apc_delete("launchdarkly:features.foo");
         $this->assertEquals("baz", $client->variation('foo', $user, 'jim'));
     }
 
     private function gen_feature($key, $val) {
-        $data = <<<EOF
-           {"name": "Feature $key", "key": "$key", "kind": "flag", "salt": "Zm9v", "on": true,
-            "variations": [{"value": "$val", "weight": 100,
-                            "targets": [{"attribute": "key", "op": "in", "values": []}],
-                            "userTarget": {"attribute": "key", "op": "in", "values": []}},
-                           {"value": false, "weight": 0,
-                            "targets": [{"attribute": "key", "op": "in", "values": []}],
-                            "userTarget": {"attribute": "key", "op": "in", "values": []}}],
-            "commitDate": "2015-09-08T21:24:16.712Z",
-            "creationDate": "2015-09-08T21:06:16.527Z",
-            "version": 4}
-EOF;
-         return $data;
+        $data = [
+            'name' => 'Feature ' . $val,
+            'key' => $key,
+            'kind' => 'flag',
+            'salt' => 'Zm9v',
+            'on' => true,
+            'variations' => [
+                $val,
+                false,
+            ],
+            'commitDate' => '2015-09-08T21:24:16.712Z',
+            'creationDate' => '2015-09-08T21:06:16.527Z',
+            'version' => 4,
+            'prerequisites' => [],
+            'targets' => [
+                [
+                    'values' => [
+                        $val,
+                    ],
+                    'variation' => 0,
+                ],
+                [
+                    'values' => [
+                        false,
+                    ],
+                    'variation' => 1,
+                ],
+            ],
+            'rules' => [],
+            'fallthrough' => [
+                'rollout' => [
+                    'variations' => [
+                        [
+                            'variation' => 0,
+                            'weight' => 95000,
+                        ],
+                        [
+                            'variation' => 1,
+                            'weight' => 5000,
+                        ],
+                    ],
+                ],
+            ],
+            'offVariation' => null,
+            'deleted' => false,
+        ];
+
+        return \json_encode($data);
     }
 
 }

--- a/integration-tests/composer.json
+++ b/integration-tests/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "monolog/monolog": "1.21.0",
         "php": ">=5.3",
         "predis/predis": "1.0.*"
     },


### PR DESCRIPTION
* update feature-generator in integration-test to return json-object with all required keys and appropriate variation-structures.
* update APC integration test to verify value is baz after setting baz directly into redis (i believe this was a problem in earlier versions as well).
* add required monolog dependency to integration test composer config.