### PR TITLE
add travis config to run unit and integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,19 @@ php:
 env:
   - COMPOSER_OPTS=""
   - COMPOSER_OPTS="--prefer-lowest"
+services:
+  - redis-server
+before_install:
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then pecl channel-update pecl.php.net; fi;
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 7.* ]]; then pecl install riak-beta; fi;
+  - if [[ $TRAVIS_PHP_VERSION = '5.5' ]] ; then echo yes | pecl install apcu-4.0.10; fi;
+  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]] ; then echo yes | pecl install apcu-4.0.10; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then pecl config-set preferred_state beta; echo yes | pecl install apcu; fi;
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./integration-tests/php.ini; fi;
 before_script:
   - composer self-update
   - composer update --no-interaction $COMPOSER_OPTS
 script:
   - vendor/bin/phpunit tests --coverage-text
+  - ln -s vendor integration-tests/vendor
+  - vendor/bin/phpunit integration-tests/LDDFeatureRequesterTest.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+before_script:
+  - composer self-update
+  - composer update --no-interaction $COMPOSER_OPTS
+script:
+  - vendor/bin/phpunit tests --coverage-text

--- a/integration-tests/LDDFeatureRequesterTest.php
+++ b/integration-tests/LDDFeatureRequesterTest.php
@@ -3,6 +3,8 @@ namespace LaunchDarkly\Tests;
 
 require_once 'vendor/autoload.php';
 
+use LaunchDarkly\ApcLDDFeatureRequester;
+use LaunchDarkly\ApcuLDDFeatureRequester;
 use LaunchDarkly\LDClient;
 use LaunchDarkly\LDUserBuilder;
 
@@ -28,8 +30,10 @@ class LDDFeatureRetrieverTest extends \PHPUnit_Framework_TestCase {
                                         "scheme" => "tcp",
                                         "host" => 'localhost',
                                         "port" => 6379));
-        $client = new LDClient("BOGUS_API_KEY", array('feature_requester_class' => '\\LaunchDarkly\\ApcLDDFeatureRequester',
-            'apc_expiration' => 1));
+        $client = new LDClient("BOGUS_API_KEY", [
+            'feature_requester_class' => extension_loaded('apcu') ? ApcuLDDFeatureRequester::class : ApcLDDFeatureRequester::class,
+            'apc_expiration' => 1,
+        ]);
         $builder = new LDUserBuilder(3);
         $user = $builder->build();
 
@@ -42,24 +46,63 @@ class LDDFeatureRetrieverTest extends \PHPUnit_Framework_TestCase {
         $redis->hset("launchdarkly:features", 'foo', $this->gen_feature("foo", "baz"));
         $this->assertEquals("bar", $client->variation('foo', $user, 'jim'));
 
-        apc_delete("launchdarkly:features.foo");
+        if (extension_loaded('apcu')) {
+            \apcu_delete("launchdarkly:features.foo");
+        } else {
+            \apc_delete("launchdarkly:features.foo");
+        }
         $this->assertEquals("baz", $client->variation('foo', $user, 'jim'));
     }
 
     private function gen_feature($key, $val) {
-        $data = <<<EOF
-           {"name": "Feature $key", "key": "$key", "kind": "flag", "salt": "Zm9v", "on": true,
-            "variations": [{"value": "$val", "weight": 100,
-                            "targets": [{"attribute": "key", "op": "in", "values": []}],
-                            "userTarget": {"attribute": "key", "op": "in", "values": []}},
-                           {"value": false, "weight": 0,
-                            "targets": [{"attribute": "key", "op": "in", "values": []}],
-                            "userTarget": {"attribute": "key", "op": "in", "values": []}}],
-            "commitDate": "2015-09-08T21:24:16.712Z",
-            "creationDate": "2015-09-08T21:06:16.527Z",
-            "version": 4}
-EOF;
-         return $data;
+        $data = [
+            'name' => 'Feature ' . $val,
+            'key' => $key,
+            'kind' => 'flag',
+            'salt' => 'Zm9v',
+            'on' => true,
+            'variations' => [
+                $val,
+                false,
+            ],
+            'commitDate' => '2015-09-08T21:24:16.712Z',
+            'creationDate' => '2015-09-08T21:06:16.527Z',
+            'version' => 4,
+            'prerequisites' => [],
+            'targets' => [
+                [
+                    'values' => [
+                        $val,
+                    ],
+                    'variation' => 0,
+                ],
+                [
+                    'values' => [
+                        false,
+                    ],
+                    'variation' => 1,
+                ],
+            ],
+            'rules' => [],
+            'fallthrough' => [
+                'rollout' => [
+                    'variations' => [
+                        [
+                            'variation' => 0,
+                            'weight' => 95000,
+                        ],
+                        [
+                            'variation' => 1,
+                            'weight' => 5000,
+                        ],
+                    ],
+                ],
+            ],
+            'offVariation' => null,
+            'deleted' => false,
+        ];
+
+        return \json_encode($data);
     }
 
 }

--- a/integration-tests/composer.json
+++ b/integration-tests/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "monolog/monolog": "1.21.0",
         "php": ">=5.3",
         "predis/predis": "1.0.*"
     },

--- a/integration-tests/php.ini
+++ b/integration-tests/php.ini
@@ -1,0 +1,4 @@
+extension="redis.so"
+
+apc.enabled=1
+apc.enable_cli=1

--- a/src/LaunchDarkly/ApcLDDFeatureRequester.php
+++ b/src/LaunchDarkly/ApcLDDFeatureRequester.php
@@ -18,10 +18,19 @@ class ApcLDDFeatureRequester extends LDDFeatureRequester {
         }
     }
 
+    /**
+     * @param $key
+     * @param $success
+     * @return mixed
+     */
+    protected function fetch($key, &$success = null)
+    {
+        return \apc_fetch($key, $success);
+    }
 
     protected function get_from_cache($key) {
         $key = self::make_cache_key($key);
-        $enabled = apc_fetch($key);
+        $enabled = $this->fetch($key);
         if ($enabled === false) {
             return null;
         }
@@ -30,8 +39,19 @@ class ApcLDDFeatureRequester extends LDDFeatureRequester {
         }
     }
 
+    /**
+     * @param $key
+     * @param $var
+     * @param int $ttl
+     * @return mixed
+     */
+    protected function add($key, $var, $ttl = 0)
+    {
+        return \apc_add($key, $var, $ttl);
+    }
+
     protected function store_in_cache($key, $val) {
-        apc_add($this->make_cache_key($key), $val, $this->_expiration);
+        $this->add($this->make_cache_key($key), $val, $this->_expiration);
     }
 
     private function make_cache_key($name) {

--- a/src/LaunchDarkly/ApcuLDDFeatureRequester.php
+++ b/src/LaunchDarkly/ApcuLDDFeatureRequester.php
@@ -1,0 +1,32 @@
+<?php
+namespace LaunchDarkly;
+
+
+/**
+ * Feature requester from an LDD-populated redis, with APC caching
+ *
+ * @package LaunchDarkly
+ */
+class ApcuLDDFeatureRequester extends ApcLDDFeatureRequester
+{
+    /**
+     * @param $key
+     * @param null $success
+     * @return mixed
+     */
+    protected function fetch($key, &$success = null)
+    {
+        return \apcu_fetch($key, $success);
+    }
+
+    /**
+     * @param $key
+     * @param $var
+     * @param int $ttl
+     * @return bool
+     */
+    protected function add($key, $var, $ttl = 0)
+    {
+        return \apcu_add($key, $var, $ttl);
+    }
+}


### PR DESCRIPTION
this is an extension of https://github.com/launchdarkly/php-client/pull/46

using travis i'm able to build minimum and maximum composer dependency versions, and run integration tests by installing the appropriate version of apc/apcu and running redis via docker service.

as i mentioned before, i hope this request doesn't come across too pushy. i am simply more familiar with travis than circle.

* add travis config to test PHP versions 5.5 to 7.1.
* each PHP version is tested with the minimum and maximum dependency versions which provides some certainty that our dependency ranges in the composer config are valid.
* update feature-generator in integration-test to return json-object with all required keys and appropriate variation-structures.
* install appropriate apc/apcu extension version based on php version.
* add apcu-feature-requester which extends the apc-feature-requester and uses the actively-maintained extension.
* add missing monolog requirement to integration-test composer config.
* run integration tests in travis.

sample build output, demonstrating that unit and integration tests pass on php55 through php71 with min and max composer dependency versions:
https://travis-ci.org/abacaphiliac/php-client/builds/184885080