### PR TITLE
build on php55-php71 via phpbrew

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,29 @@
 machine:
   php:
     version: 5.6.17
+dependencies:
+  pre:
+    - curl -s -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
+    - chmod +x phpbrew
+    - sudo mv phpbrew /usr/bin/phpbrew
+    - phpbrew init
+    - phpbrew known --update
+    - phpbrew update
+    - phpbrew install 5.5.38
+    - phpbrew install 7.0.14
+    - phpbrew install 7.1.0
 
 test:
   override:
     - vendor/bin/phpunit tests --coverage-text
+    - composer update && vendor/bin/phpunit tests
+    - composer update --prefer-lowest && vendor/bin/phpunit tests
+
+    - source ~/.phpbrew/bashrc && phpbrew switch 5.5.38 && php -v && composer update && vendor/bin/phpunit tests
+    - source ~/.phpbrew/bashrc && phpbrew switch 5.5.38 && php -v && composer update --prefer-lowest && vendor/bin/phpunit tests
+
+    - source ~/.phpbrew/bashrc && phpbrew switch 7.0.14 && php -v && composer update && vendor/bin/phpunit tests
+    - source ~/.phpbrew/bashrc && phpbrew switch 7.0.14 && php -v && composer update --prefer-lowest && vendor/bin/phpunit tests
+
+    - source ~/.phpbrew/bashrc && phpbrew switch 7.1.0 && php -v && composer update && vendor/bin/phpunit tests
+    - source ~/.phpbrew/bashrc && phpbrew switch 7.1.0 && php -v && composer update --prefer-lowest && vendor/bin/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "6.2.1",
         "kevinrob/guzzle-cache-middleware": "1.4.1",
-        "phpunit/phpunit": "4.8.26",
+        "phpunit/phpunit": ">=4.8.26 <5.4",
         "phpdocumentor/phpdocumentor": "2.*",
         "predis/predis": "1.0.*",
         "zendframework/zend-serializer": "2.7.*"


### PR DESCRIPTION
install php55-php71 with phpbrew. run tests after installing minimum and maximum dependency versions allowed by composer config.

this is one of two (and not my favorite) competing solutions to my Travis CI solution:
https://github.com/launchdarkly/php-client/pull/46

here is a sample build:
https://circleci.com/gh/abacaphiliac/php-client/25

it gets the job done, but it took >25 minutes to do it. that's just plain unreasonable in my opinion. but i promised @drichelson i would give it a go, so here it is. i'll post another variant next : )

i did look into parallel execution although it seems CircleCI is built to parallelize test execution via file-pattern instead of machine/dependency and this solution's biggest time suck is in the dependency stage.