### PR TITLE
build on php55-php71 via docker

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,24 @@
 machine:
   php:
     version: 5.6.17
+  services:
+      - docker
+dependencies:
+  pre:
+    - docker pull php
+    - docker pull nyanpass/php5.5
 
 test:
   override:
     - vendor/bin/phpunit tests --coverage-text
+    - composer update && vendor/bin/phpunit tests
+    - composer update --prefer-lowest && vendor/bin/phpunit tests
+
+    - docker run -it -v `pwd`:/php-client php:7.0-alpine sh -c "php -v && php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin && cd /php-client && composer.phar update && vendor/bin/phpunit"
+    - docker run -it -v `pwd`:/php-client php:7.0-alpine sh -c "php -v && php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin && cd /php-client && composer.phar update --prefer-lowest && vendor/bin/phpunit"
+
+    - docker run -it -v `pwd`:/php-client php:7.1-alpine sh -c "php -v && php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin && cd /php-client && composer.phar update && vendor/bin/phpunit"
+    - docker run -it -v `pwd`:/php-client php:7.1-alpine sh -c "php -v && php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin && cd /php-client && composer.phar update --prefer-lowest && vendor/bin/phpunit"
+
+    - docker run -it -v `pwd`:/php-client nyanpass/php5.5:5.5-alpine sh -c "php -v && php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin && cd /php-client && composer.phar update && vendor/bin/phpunit"
+    - docker run -it -v `pwd`:/php-client nyanpass/php5.5:5.5-alpine sh -c "php -v && php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin && cd /php-client && composer.phar update --prefer-lowest && vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "6.2.1",
         "kevinrob/guzzle-cache-middleware": "1.4.1",
-        "phpunit/phpunit": "4.8.26",
+        "phpunit/phpunit": ">=4.8.26 <5.4",
         "phpdocumentor/phpdocumentor": "2.*",
         "predis/predis": "1.0.*",
         "zendframework/zend-serializer": "2.7.*"


### PR DESCRIPTION
install php55-php71 with docker. run tests after installing minimum and maximum dependency versions allowed by composer config.

this is one of two competing solutions to my Travis CI solution:
#46

here is a sample build:
https://circleci.com/gh/abacaphiliac/php-client/21

it gets the job done in ~10 minutes which is a significant improvement over my phpbrew CircleCI solution:
#50 

this one is better than #50, but still not quite as good as the machine-parallelized matrix builds of TravisCI which accomplishes the same goal but in ~5 minutes:
https://travis-ci.org/abacaphiliac/php-client/builds/184626287

@drichelson please let me know what you think about these solutions and which one(s) you would like me to explore further.