### PR TITLE
Fixing variant retrieving when toggle is off

### DIFF
--- a/src/LaunchDarkly/FeatureFlag.php
+++ b/src/LaunchDarkly/FeatureFlag.php
@@ -88,7 +88,7 @@ class FeatureFlag {
         }
         if ($this->isOn()) {
             $result = $this->_evaluate($user, $featureRequester, $prereqEvents);
-            if ($result != null) {
+            if ($result !== null) {
                 return new EvalResult($result, $prereqEvents);
             }
         }

--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -131,7 +131,7 @@ class LDClient {
                     $this->_eventProcessor->enqueue($e);
                 }
             }
-            if ($evalResult->getValue() != null) {
+            if ($evalResult->getValue() !== null) {
                 $this->_sendFlagRequestEvent($key, $user, $evalResult->getValue(), $default, $flag->getVersion());
                 return $evalResult->getValue();
             }


### PR DESCRIPTION
Since now it didn't change if you had your toggle Off or On with false, as both options where returning null when asking for the variant value. It happens that null is not exactly the same as false, this fixes it and now properly returns a false when it's false. This problem also happened when any of your multivariant values was a false too

Hope we can fix this, as we need it for properly A/B testing 😄