### PR TITLE
add integration tests to CircleCI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,15 +2,21 @@ machine:
   php:
     version: 5.6.17
   services:
+      - redis
       - docker
 dependencies:
   pre:
+    - yes '' | pecl install -f apcu-4.0.10
+    - echo "extension=apcu.so" | sudo tee -a /opt/circleci/php/$(phpenv global)/etc/php.ini
     - docker pull php
     - docker pull nyanpass/php5.5
 
 test:
   override:
     - vendor/bin/phpunit tests --coverage-text
+    - ln -s vendor integration-tests/vendor
+    - vendor/bin/phpunit integration-tests/LDDFeatureRequesterTest.php
+
     - composer update && vendor/bin/phpunit tests
     - composer update --prefer-lowest && vendor/bin/phpunit tests
 

--- a/integration-tests/composer.json
+++ b/integration-tests/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "monolog/monolog": "1.21.0",
         "php": ">=5.3",
         "predis/predis": "1.0.*"
     },

--- a/src/LaunchDarkly/ApcLDDFeatureRequester.php
+++ b/src/LaunchDarkly/ApcLDDFeatureRequester.php
@@ -18,10 +18,19 @@ class ApcLDDFeatureRequester extends LDDFeatureRequester {
         }
     }
 
+    /**
+     * @param $key
+     * @param $success
+     * @return mixed
+     */
+    protected function fetch($key, &$success = null)
+    {
+        return \apc_fetch($key, $success);
+    }
 
     protected function get_from_cache($key) {
         $key = self::make_cache_key($key);
-        $enabled = apc_fetch($key);
+        $enabled = $this->fetch($key);
         if ($enabled === false) {
             return null;
         }
@@ -30,8 +39,19 @@ class ApcLDDFeatureRequester extends LDDFeatureRequester {
         }
     }
 
+    /**
+     * @param $key
+     * @param $var
+     * @param int $ttl
+     * @return mixed
+     */
+    protected function add($key, $var, $ttl = 0)
+    {
+        return \apc_add($key, $var, $ttl);
+    }
+
     protected function store_in_cache($key, $val) {
-        apc_add($this->make_cache_key($key), $val, $this->_expiration);
+        $this->add($this->make_cache_key($key), $val, $this->_expiration);
     }
 
     private function make_cache_key($name) {

--- a/src/LaunchDarkly/ApcuLDDFeatureRequester.php
+++ b/src/LaunchDarkly/ApcuLDDFeatureRequester.php
@@ -1,0 +1,32 @@
+<?php
+namespace LaunchDarkly;
+
+
+/**
+ * Feature requester from an LDD-populated redis, with APC caching
+ *
+ * @package LaunchDarkly
+ */
+class ApcuLDDFeatureRequester extends ApcLDDFeatureRequester
+{
+    /**
+     * @param $key
+     * @param null $success
+     * @return mixed
+     */
+    protected function fetch($key, &$success = null)
+    {
+        return \apcu_fetch($key, $success);
+    }
+
+    /**
+     * @param $key
+     * @param $var
+     * @param int $ttl
+     * @return bool
+     */
+    protected function add($key, $var, $ttl = 0)
+    {
+        return \apcu_add($key, $var, $ttl);
+    }
+}


### PR DESCRIPTION
add integration tests to CircleCI build. starts redis server on CircleCI and installs apcu extension on php56. add APCU-feature-requester which is the >=php55 version of the <=php54 APC-feature-requester.

integration tests fail in CI, which is consistent with my Vagrant VM experience:
```
 upgraded, 25 newly installed, 0 to remove and 5 not upgraded.
==> default: Need to get 6,468 kB of archives.
==> default: After this operation, 30.4 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libapr1 amd64 1.5.0-1 [85.1 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1 amd64 1.5.3-1 [76.4 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-cli amd64 5.5.9+dfsg-1ubuntu4.20 [2,164 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-readline amd64 5.5.9+dfsg-1ubuntu4.20 [12.1 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1-dbd-sqlite3 amd64 1.5.3-1 [10.5 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1-ldap amd64 1.5.3-1 [8,634 B]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2-bin amd64 2.4.7-1ubuntu4.13 [839 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2-data all 2.4.7-1ubuntu4.13 [160 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2 amd64 2.4.7-1ubuntu4.13 [87.4 kB]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libapache2-mod-php5 amd64 5.5.9+dfsg-1ubuntu4.20 [2,210 kB]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php-pear all 5.5.9+dfsg-1ubuntu4.20 [267 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty/universe pear-channels all 0~20131124-1 [5,846 B]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5 all 5.5.9+dfsg-1ubuntu4.20 [1,306 B]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty/universe php-file-iterator all 1.3.1-2 [7,702 B]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty/universe php-token-stream all 1.1.3-2 [12.4 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/universe php-text-template all 1.1.1-2 [6,070 B]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty/universe php-codecoverage all 1.2.13+dfsg1-1 [76.5 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/universe php-timer all 1.0.5-1 [6,016 B]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/universe php-invoker all 1.1.0-1 [6,134 B]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty/universe php-symfony2-yaml all 2.4.1-1 [16.6 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/universe php5-xdebug amd64 2.2.3-2build1 [253 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit-mock-object all 1.2.3-1 [23.6 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit all 3.7.28-1 [104 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit-story all 1.0.0-3 [11.4 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty/main ssl-cert all 1.0.33 [16.6 kB]
==> default: Fetched 6,468 kB in 12s (506 kB/s)
==> default: Selecting previously unselected package libapr1:amd64.
==> default: (Reading database ... 63943 files and directories currently installed.)
==> default: Preparing to unpack .../libapr1_1.5.0-1_amd64.deb ...
==> default: Unpacking libapr1:amd64 (1.5.0-1) ...
==> default: Selecting previously unselected package libaprutil1:amd64.
==> default: Preparing to unpack .../libaprutil1_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package php5-cli.
==> default: Preparing to unpack .../php5-cli_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-cli (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php5-readline.
==> default: Preparing to unpack .../php5-readline_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-readline (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package libaprutil1-dbd-sqlite3:amd64.
==> default: Preparing to unpack .../libaprutil1-dbd-sqlite3_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1-dbd-sqlite3:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package libaprutil1-ldap:amd64.
==> default: Preparing to unpack .../libaprutil1-ldap_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1-ldap:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package apache2-bin.
==> default: Preparing to unpack .../apache2-bin_2.4.7-1ubuntu4.13_amd64.deb ...
==> default: Unpacking apache2-bin (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package apache2-data.
==> default: Preparing to unpack .../apache2-data_2.4.7-1ubuntu4.13_all.deb ...
==> default: Unpacking apache2-data (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package apache2.
==> default: Preparing to unpack .../apache2_2.4.7-1ubuntu4.13_amd64.deb ...
==> default: Unpacking apache2 (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package libapache2-mod-php5.
==> default: Preparing to unpack .../libapache2-mod-php5_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking libapache2-mod-php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php-pear.
==> default: Preparing to unpack .../php-pear_5.5.9+dfsg-1ubuntu4.20_all.deb ...
==> default: Unpacking php-pear (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package pear-channels.
==> default: Preparing to unpack .../pear-channels_0~20131124-1_all.deb ...
==> default: Unpacking pear-channels (0~20131124-1) ...
==> default: Selecting previously unselected package php5.
==> default: Preparing to unpack .../php5_5.5.9+dfsg-1ubuntu4.20_all.deb ...
==> default: Unpacking php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php-file-iterator.
==> default: Preparing to unpack .../php-file-iterator_1.3.1-2_all.deb ...
==> default: Unpacking php-file-iterator (1.3.1-2) ...
==> default: Selecting previously unselected package php-token-stream.
==> default: Preparing to unpack .../php-token-stream_1.1.3-2_all.deb ...
==> default: Unpacking php-token-stream (1.1.3-2) ...
==> default: Selecting previously unselected package php-text-template.
==> default: Preparing to unpack .../php-text-template_1.1.1-2_all.deb ...
==> default: Unpacking php-text-template (1.1.1-2) ...
==> default: Selecting previously unselected package php-codecoverage.
==> default: Preparing to unpack .../php-codecoverage_1.2.13+dfsg1-1_all.deb ...
==> default: Unpacking php-codecoverage (1.2.13+dfsg1-1) ...
==> default: Selecting previously unselected package php-timer.
==> default: Preparing to unpack .../php-timer_1.0.5-1_all.deb ...
==> default: Unpacking php-timer (1.0.5-1) ...
==> default: Selecting previously unselected package php-invoker.
==> default: Preparing to unpack .../php-invoker_1.1.0-1_all.deb ...
==> default: Unpacking php-invoker (1.1.0-1) ...
==> default: Selecting previously unselected package php-symfony2-yaml.
==> default: Preparing to unpack .../php-symfony2-yaml_2.4.1-1_all.deb ...
==> default: Unpacking php-symfony2-yaml (2.4.1-1) ...
==> default: Selecting previously unselected package php5-xdebug.
==> default: Preparing to unpack .../php5-xdebug_2.2.3-2build1_amd64.deb ...
==> default: Unpacking php5-xdebug (2.2.3-2build1) ...
==> default: Selecting previously unselected package phpunit-mock-object.
==> default: Preparing to unpack .../phpunit-mock-object_1.2.3-1_all.deb ...
==> default: Unpacking phpunit-mock-object (1.2.3-1) ...
==> default: Selecting previously unselected package phpunit.
==> default: Preparing to unpack .../phpunit_3.7.28-1_all.deb ...
==> default: Unpacking phpunit (3.7.28-1) ...
==> default: Selecting previously unselected package phpunit-story.
==> default: Preparing to unpack .../phpunit-story_1.0.0-3_all.deb ...
==> default: Unpacking phpunit-story (1.0.0-3) ...
==> default: Selecting previously unselected package ssl-cert.
==> default: Preparing to unpack .../ssl-cert_1.0.33_all.deb ...
==> default: Unpacking ssl-cert (1.0.33) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for ufw (0.34~rc-0ubuntu2) ...
==> default: Setting up libapr1:amd64 (1.5.0-1) ...
==> default: Setting up libaprutil1:amd64 (1.5.3-1) ...
==> default: Setting up php5-cli (5.5.9+dfsg-1ubuntu4.20) ...
==> default: update-alternatives: 
==> default: using /usr/bin/php5 to provide /usr/bin/php (php) in auto mode
==> default: Setting up php5-readline (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up libaprutil1-dbd-sqlite3:amd64 (1.5.3-1) ...
==> default: Setting up libaprutil1-ldap:amd64 (1.5.3-1) ...
==> default: Setting up apache2-bin (2.4.7-1ubuntu4.13) ...
==> default: Setting up apache2-data (2.4.7-1ubuntu4.13) ...
==> default: Setting up apache2 (2.4.7-1ubuntu4.13) ...
==> default: Enabling module mpm_event.
==> default: Enabling module authz_core.
==> default: Enabling module authz_host.
==> default: Enabling module authn_core.
==> default: Enabling module auth_basic.
==> default: Enabling module access_compat.
==> default: Enabling module authn_file.
==> default: Enabling module authz_user.
==> default: Enabling module alias.
==> default: Enabling module dir.
==> default: Enabling module autoindex.
==> default: Enabling module env.
==> default: Enabling module mime.
==> default: Enabling module negotiation.
==> default: Enabling module setenvif.
==> default: Enabling module filter.
==> default: Enabling module deflate.
==> default: Enabling module status.
==> default: Enabling conf charset.
==> default: Enabling conf localized-error-pages.
==> default: Enabling conf other-vhosts-access-log.
==> default: Enabling conf security.
==> default: Enabling conf serve-cgi-bin.
==> default: Enabling site 000-default.
==> default:  * Starting web server apache2
==> default:  * 
==> default: Setting up php-pear (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up pear-channels (0~20131124-1) ...
==> default: Setting up php-timer (1.0.5-1) ...
==> default: Setting up php-invoker (1.1.0-1) ...
==> default: Setting up php-symfony2-yaml (2.4.1-1) ...
==> default: Setting up php5-xdebug (2.2.3-2build1) ...
==> default: Setting up ssl-cert (1.0.33) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for ufw (0.34~rc-0ubuntu2) ...
==> default: Setting up libapache2-mod-php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Module mpm_event disabled.
==> default: Enabling module mpm_prefork.
==> default:  * Restarting web server apache2
==> default:    ...done.
==> default:  * Restarting web server apache2
==> default:    ...done.
==> default: Setting up php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up php-file-iterator (1.3.1-2) ...
==> default: Setting up php-token-stream (1.1.3-2) ...
==> default: Setting up php-text-template (1.1.1-2) ...
==> default: Setting up php-codecoverage (1.2.13+dfsg1-1) ...
==> default: Setting up phpunit-mock-object (1.2.3-1) ...
==> default: Setting up phpunit (3.7.28-1) ...
==> default: Setting up phpunit-story (1.0.0-3) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following NEW packages will be installed:
==> default:   apache2-dev aspell aspell-en autoconf automake autotools-dev bison
==> default:   build-essential chrpath comerr-dev debhelper dh-apparmor dictionaries-common
==> default:   dpkg-dev flex freetds-common freetds-dev g++ g++-4.8 gettext icu-devtools
==> default:   intltool-debian krb5-multidev language-pack-de language-pack-de-base libaio1
==> default:   libapr1-dev libaprutil1-dev libaspell-dev libaspell15 libbison-dev
==> default:   libbsd-dev libbz2-dev libcroco3 libct4 libcurl4-openssl-dev libdb-dev
==> default:   libdb5.3-dev libdbd-mysql-perl libdbi-perl libdpkg-perl libedit-dev libelfg0
==> default:   libenchant-dev libenchant1c2a libevent-core-2.0-5 libevent-dev
==> default:   libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5
==> default:   libexpat1-dev libfl-dev libfontconfig1-dev libfreetype6-dev libgcrypt11-dev
==> default:   libgd-dev libglib2.0-bin libglib2.0-dev libgmp-dev libgmp3-dev libgmpxx4ldbl
==> default:   libgnutls-dev libgnutlsxx27 libgpg-error-dev libgssrpc4 libhunspell-1.3-0
==> default:   libice-dev libicu-dev libidn11-dev libjbig-dev libjpeg-dev
==> default:   libjpeg-turbo8-dev libjpeg8-dev libkadm5clnt-mit9 libkadm5srv-mit9 libkdb5-7
==> default:   libkrb5-dev libldap2-dev libltdl-dev liblzma-dev libmagic-dev libmhash-dev
==> default:   libmhash2 libmysqlclient-dev libmysqlclient18 libodbc1 libp11-kit-dev
==> default:   libpam0g-dev libpcre3-dev libpcrecpp0 libperl5.18 libpng12-dev libpq-dev
==> default:   libpq5 libpspell-dev libpthread-stubs0-dev librecode-dev librecode0
==> default:   librtmp-dev libsasl2-dev libsctp-dev libsctp1 libsensors4 libsensors4-dev
==> default:   libsm-dev libsnmp-base libsnmp-dev libsnmp30 libsqlite3-dev libssl-dev
==> default:   libstdc++-4.8-dev libsybdb5 libsystemd-daemon-dev libtasn1-6-dev
==> default:   libterm-readkey-perl libtidy-0.99-0 libtidy-dev libtiff5-dev libtiffxx5
==> default:   libtinfo-dev libtool libunistring0 libvpx-dev libwrap0-dev libx11-dev
==> default:   libxau-dev libxcb1-dev libxdmcp-dev libxml2-dev libxmltok1 libxmltok1-dev
==> default:   libxpm-dev libxslt1-dev libxslt1.1 libxt-dev m4 mysql-client-5.5
==> default:   mysql-client-core-5.5 mysql-common mysql-server mysql-server-5.5
==> default:   mysql-server-core-5.5 odbcinst odbcinst1debian2 pkg-config po-debconf re2c
==> default:   systemtap-sdt-dev unixodbc unixodbc-dev uuid-dev x11proto-core-dev
==> default:   x11proto-input-dev x11proto-kb-dev xorg-sgml-doctools xtrans-dev zlib1g-dev
==> default: 0 upgraded, 157 newly installed, 0 to remove and 5 not upgraded.
==> default: Need to get 68.8 MB of archives.
==> default: After this operation, 329 MB of additional disk space will be used.
==> default: Do you want to continue?
==> default:  [Y/n] 
==> default: Abort.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: curl is already the newest version.
==> default: libxml2 is already the newest version.
==> default: php-pear is already the newest version.
==> default: php-pear set to manually installed.
==> default: php5 is already the newest version.
==> default: php5 set to manually installed.
==> default: php5-cli is already the newest version.
==> default: php5-cli set to manually installed.
==> default: The following extra packages will be installed:
==> default:   autotools-dev debhelper dh-apparmor dpkg-dev g++ g++-4.8 gettext
==> default:   intltool-debian libalgorithm-diff-perl libalgorithm-diff-xs-perl
==> default:   libalgorithm-merge-perl libasprintf-dev libbison-dev libcroco3 libdpkg-perl
==> default:   libfile-fcntllock-perl libgettextpo-dev libgettextpo0 libltdl-dev
==> default:   libmail-sendmail-perl libreadline6-dev libssl-dev libssl-doc
==> default:   libstdc++-4.8-dev libsys-hostname-long-perl libtinfo-dev libtool
==> default:   libunistring0 libxslt1.1 m4 pkg-php-tools po-debconf shtool zlib1g-dev
==> default: Suggested packages:
==> default:   autoconf2.13 autoconf-archive gnu-standards autoconf-doc bison-doc dh-make
==> default:   apparmor-easyprof debian-keyring g++-multilib g++-4.8-multilib gcc-4.8-doc
==> default:   libstdc++6-4.8-dbg gettext-doc libtool-doc libstdc++-4.8-doc automaken
==> default:   gfortran fortran95-compiler gcj-jdk pkg-config libmail-box-perl
==> default: The following NEW packages will be installed:
==> default:   autoconf automake autotools-dev bison build-essential debhelper dh-apparmor
==> default:   dpkg-dev g++ g++-4.8 gettext intltool-debian libalgorithm-diff-perl
==> default:   libalgorithm-diff-xs-perl libalgorithm-merge-perl libasprintf-dev
==> default:   libbison-dev libbz2-dev libcroco3 libdpkg-perl libfile-fcntllock-perl
==> default:   libgettextpo-dev libgettextpo0 libltdl-dev libmail-sendmail-perl
==> default:   libreadline-dev libreadline6-dev libssl-dev libssl-doc libstdc++-4.8-dev
==> default:   libsys-hostname-long-perl libtinfo-dev libtool libunistring0 libxml2-dev
==> default:   libxslt1-dev libxslt1.1 m4 php5-dev pkg-php-tools po-debconf re2c shtool
==> default:   zlib1g-dev
==> default: 0 upgraded, 44 newly installed, 0 to remove and 5 not upgraded.
==> default: Need to get 29.0 MB of archives.
==> default: After this operation, 80.4 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libcroco3 amd64 0.6.8-2ubuntu1 [82.4 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libunistring0 amd64 0.9.3-5ubuntu3 [271 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgettextpo0 amd64 0.18.3.1-1ubuntu3 [108 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty/main libxslt1.1 amd64 1.1.28-2build1 [145 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main m4 amd64 1.4.17-2ubuntu1 [195 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main autoconf all 2.69-6 [322 kB]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty/main autotools-dev all 20130810.1 [44.3 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty/main automake all 1:1.14.1-2ubuntu1 [510 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty/main libbison-dev amd64 2:3.0.2.dfsg-2 [338 kB]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty/main bison amd64 2:3.0.2.dfsg-2 [257 kB]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libstdc++-4.8-dev amd64 4.8.4-2ubuntu1~14.04.3 [1,053 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty-updates/main g++-4.8 amd64 4.8.4-2ubuntu1~14.04.3 [18.1 MB]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty/main g++ amd64 4:4.8.2-1ubuntu6 [1,490 B]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libdpkg-perl all 1.17.5ubuntu5.7 [179 kB]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty-updates/main dpkg-dev all 1.17.5ubuntu5.7 [726 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/main build-essential amd64 11.6ubuntu6 [4,838 B]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty-updates/main gettext amd64 0.18.3.1-1ubuntu3 [829 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/main intltool-debian all 0.35.0+20060710.1 [31.6 kB]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/main po-debconf all 1.0.16+nmu2ubuntu1 [210 kB]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty-updates/main dh-apparmor all 2.8.95~2430-0ubuntu5.3 [12.2 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/main debhelper all 9.20131227ubuntu1 [604 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-perl all 1.19.02-3 [50.0 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-xs-perl amd64 0.04-2build4 [12.6 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-merge-perl all 0.08-2 [12.7 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libasprintf-dev amd64 0.18.3.1-1ubuntu3 [4,438 B]
==> default: Get:26 http://archive.ubuntu.com/ubuntu/ trusty/main libbz2-dev amd64 1.0.6-5 [33.2 kB]
==> default: Get:27 http://archive.ubuntu.com/ubuntu/ trusty/main libfile-fcntllock-perl amd64 0.14-2build1 [15.9 kB]
==> default: Get:28 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgettextpo-dev amd64 0.18.3.1-1ubuntu3 [122 kB]
==> default: Get:29 http://archive.ubuntu.com/ubuntu/ trusty/main libltdl-dev amd64 2.4.2-1.7ubuntu1 [157 kB]
==> default: Get:30 http://archive.ubuntu.com/ubuntu/ trusty/main libsys-hostname-long-perl all 1.4-3 [11.3 kB]
==> default: Get:31 http://archive.ubuntu.com/ubuntu/ trusty/main libmail-sendmail-perl all 0.79.16-1 [26.5 kB]
==> default: Get:32 http://archive.ubuntu.com/ubuntu/ trusty/main libtinfo-dev amd64 5.9+20140118-1ubuntu1 [76.3 kB]
==> default: Get:33 http://archive.ubuntu.com/ubuntu/ trusty/main libreadline6-dev amd64 6.3-4ubuntu2 [213 kB]
==> default: Get:34 http://archive.ubuntu.com/ubuntu/ trusty/main libreadline-dev amd64 6.3-4ubuntu2 [988 B]
==> default: Get:35 http://archive.ubuntu.com/ubuntu/ trusty/main zlib1g-dev amd64 1:1.2.8.dfsg-1ubuntu1 [183 kB]
==> default: Get:36 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-dev amd64 1.0.1f-1ubuntu2.21 [1,074 kB]
==> default: Get:37 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-doc all 1.0.1f-1ubuntu2.21 [971 kB]
==> default: Get:38 http://archive.ubuntu.com/ubuntu/ trusty/main libtool amd64 2.4.2-1.7ubuntu1 [188 kB]
==> default: Get:39 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libxml2-dev amd64 2.9.1+dfsg1-3ubuntu4.8 [631 kB]
==> default: Get:40 http://archive.ubuntu.com/ubuntu/ trusty/main libxslt1-dev amd64 1.1.28-2build1 [407 kB]
==> default: Get:41 http://archive.ubuntu.com/ubuntu/ trusty/main shtool all 2.0.8-6 [149 kB]
==> default: Get:42 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-dev amd64 5.5.9+dfsg-1ubuntu4.20 [356 kB]
==> default: Get:43 http://archive.ubuntu.com/ubuntu/ trusty/main re2c amd64 0.13.5-1build2 [208 kB]
==> default: Get:44 http://archive.ubuntu.com/ubuntu/ trusty/main pkg-php-tools all 1.11 [21.6 kB]
==> default: Fetched 29.0 MB in 26s (1,094 kB/s)
==> default: Selecting previously unselected package libcroco3:amd64.
==> default: (Reading database ... 65226 files and directories currently installed.)
==> default: Preparing to unpack .../libcroco3_0.6.8-2ubuntu1_amd64.deb ...
==> default: Unpacking libcroco3:amd64 (0.6.8-2ubuntu1) ...
==> default: Selecting previously unselected package libunistring0:amd64.
==> default: Preparing to unpack .../libunistring0_0.9.3-5ubuntu3_amd64.deb ...
==> default: Unpacking libunistring0:amd64 (0.9.3-5ubuntu3) ...
==> default: Selecting previously unselected package libgettextpo0:amd64.
==> default: Preparing to unpack .../libgettextpo0_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libgettextpo0:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libxslt1.1:amd64.
==> default: Preparing to unpack .../libxslt1.1_1.1.28-2build1_amd64.deb ...
==> default: Unpacking libxslt1.1:amd64 (1.1.28-2build1) ...
==> default: Selecting previously unselected package m4.
==> default: Preparing to unpack .../m4_1.4.17-2ubuntu1_amd64.deb ...
==> default: Unpacking m4 (1.4.17-2ubuntu1) ...
==> default: Selecting previously unselected package autoconf.
==> default: Preparing to unpack .../autoconf_2.69-6_all.deb ...
==> default: Unpacking autoconf (2.69-6) ...
==> default: Selecting previously unselected package autotools-dev.
==> default: Preparing to unpack .../autotools-dev_20130810.1_all.deb ...
==> default: Unpacking autotools-dev (20130810.1) ...
==> default: Selecting previously unselected package automake.
==> default: Preparing to unpack .../automake_1%3a1.14.1-2ubuntu1_all.deb ...
==> default: Unpacking automake (1:1.14.1-2ubuntu1) ...
==> default: Selecting previously unselected package libbison-dev:amd64.
==> default: Preparing to unpack .../libbison-dev_2%3a3.0.2.dfsg-2_amd64.deb ...
==> default: Unpacking libbison-dev:amd64 (2:3.0.2.dfsg-2) ...
==> default: Selecting previously unselected package bison.
==> default: Preparing to unpack .../bison_2%3a3.0.2.dfsg-2_amd64.deb ...
==> default: Unpacking bison (2:3.0.2.dfsg-2) ...
==> default: Selecting previously unselected package libstdc++-4.8-dev:amd64.
==> default: Preparing to unpack .../libstdc++-4.8-dev_4.8.4-2ubuntu1~14.04.3_amd64.deb ...
==> default: Unpacking libstdc++-4.8-dev:amd64 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Selecting previously unselected package g++-4.8.
==> default: Preparing to unpack .../g++-4.8_4.8.4-2ubuntu1~14.04.3_amd64.deb ...
==> default: Unpacking g++-4.8 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Selecting previously unselected package g++.
==> default: Preparing to unpack .../g++_4%3a4.8.2-1ubuntu6_amd64.deb ...
==> default: Unpacking g++ (4:4.8.2-1ubuntu6) ...
==> default: Selecting previously unselected package libdpkg-perl.
==> default: Preparing to unpack .../libdpkg-perl_1.17.5ubuntu5.7_all.deb ...
==> default: Unpacking libdpkg-perl (1.17.5ubuntu5.7) ...
==> default: Selecting previously unselected package dpkg-dev.
==> default: Preparing to unpack .../dpkg-dev_1.17.5ubuntu5.7_all.deb ...
==> default: Unpacking dpkg-dev (1.17.5ubuntu5.7) ...
==> default: Selecting previously unselected package build-essential.
==> default: Preparing to unpack .../build-essential_11.6ubuntu6_amd64.deb ...
==> default: Unpacking build-essential (11.6ubuntu6) ...
==> default: Selecting previously unselected package gettext.
==> default: Preparing to unpack .../gettext_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking gettext (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package intltool-debian.
==> default: Preparing to unpack .../intltool-debian_0.35.0+20060710.1_all.deb ...
==> default: Unpacking intltool-debian (0.35.0+20060710.1) ...
==> default: Selecting previously unselected package po-debconf.
==> default: Preparing to unpack .../po-debconf_1.0.16+nmu2ubuntu1_all.deb ...
==> default: Unpacking po-debconf (1.0.16+nmu2ubuntu1) ...
==> default: Selecting previously unselected package dh-apparmor.
==> default: Preparing to unpack .../dh-apparmor_2.8.95~2430-0ubuntu5.3_all.deb ...
==> default: Unpacking dh-apparmor (2.8.95~2430-0ubuntu5.3) ...
==> default: Selecting previously unselected package debhelper.
==> default: Preparing to unpack .../debhelper_9.20131227ubuntu1_all.deb ...
==> default: Unpacking debhelper (9.20131227ubuntu1) ...
==> default: Selecting previously unselected package libalgorithm-diff-perl.
==> default: Preparing to unpack .../libalgorithm-diff-perl_1.19.02-3_all.deb ...
==> default: Unpacking libalgorithm-diff-perl (1.19.02-3) ...
==> default: Selecting previously unselected package libalgorithm-diff-xs-perl.
==> default: Preparing to unpack .../libalgorithm-diff-xs-perl_0.04-2build4_amd64.deb ...
==> default: Unpacking libalgorithm-diff-xs-perl (0.04-2build4) ...
==> default: Selecting previously unselected package libalgorithm-merge-perl.
==> default: Preparing to unpack .../libalgorithm-merge-perl_0.08-2_all.deb ...
==> default: Unpacking libalgorithm-merge-perl (0.08-2) ...
==> default: Selecting previously unselected package libasprintf-dev:amd64.
==> default: Preparing to unpack .../libasprintf-dev_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libasprintf-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libbz2-dev:amd64.
==> default: Preparing to unpack .../libbz2-dev_1.0.6-5_amd64.deb ...
==> default: Unpacking libbz2-dev:amd64 (1.0.6-5) ...
==> default: Selecting previously unselected package libfile-fcntllock-perl.
==> default: Preparing to unpack .../libfile-fcntllock-perl_0.14-2build1_amd64.deb ...
==> default: Unpacking libfile-fcntllock-perl (0.14-2build1) ...
==> default: Selecting previously unselected package libgettextpo-dev:amd64.
==> default: Preparing to unpack .../libgettextpo-dev_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libgettextpo-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libltdl-dev:amd64.
==> default: Preparing to unpack .../libltdl-dev_2.4.2-1.7ubuntu1_amd64.deb ...
==> default: Unpacking libltdl-dev:amd64 (2.4.2-1.7ubuntu1) ...
==> default: Selecting previously unselected package libsys-hostname-long-perl.
==> default: Preparing to unpack .../libsys-hostname-long-perl_1.4-3_all.deb ...
==> default: Unpacking libsys-hostname-long-perl (1.4-3) ...
==> default: Selecting previously unselected package libmail-sendmail-perl.
==> default: Preparing to unpack .../libmail-sendmail-perl_0.79.16-1_all.deb ...
==> default: Unpacking libmail-sendmail-perl (0.79.16-1) ...
==> default: Selecting previously unselected package libtinfo-dev:amd64.
==> default: Preparing to unpack .../libtinfo-dev_5.9+20140118-1ubuntu1_amd64.deb ...
==> default: Unpacking libtinfo-dev:amd64 (5.9+20140118-1ubuntu1) ...
==> default: Selecting previously unselected package libreadline6-dev:amd64.
==> default: Preparing to unpack .../libreadline6-dev_6.3-4ubuntu2_amd64.deb ...
==> default: Unpacking libreadline6-dev:amd64 (6.3-4ubuntu2) ...
==> default: Selecting previously unselected package libreadline-dev:amd64.
==> default: Preparing to unpack .../libreadline-dev_6.3-4ubuntu2_amd64.deb ...
==> default: Unpacking libreadline-dev:amd64 (6.3-4ubuntu2) ...
==> default: Selecting previously unselected package zlib1g-dev:amd64.
==> default: Preparing to unpack .../zlib1g-dev_1%3a1.2.8.dfsg-1ubuntu1_amd64.deb ...
==> default: Unpacking zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...
==> default: Selecting previously unselected package libssl-dev:amd64.
==> default: Preparing to unpack .../libssl-dev_1.0.1f-1ubuntu2.21_amd64.deb ...
==> default: Unpacking libssl-dev:amd64 (1.0.1f-1ubuntu2.21) ...
==> default: Selecting previously unselected package libssl-doc.
==> default: Preparing to unpack .../libssl-doc_1.0.1f-1ubuntu2.21_all.deb ...
==> default: Unpacking libssl-doc (1.0.1f-1ubuntu2.21) ...
==> default: Selecting previously unselected package libtool.
==> default: Preparing to unpack .../libtool_2.4.2-1.7ubuntu1_amd64.deb ...
==> default: Unpacking libtool (2.4.2-1.7ubuntu1) ...
==> default: Selecting previously unselected package libxml2-dev:amd64.
==> default: Preparing to unpack .../libxml2-dev_2.9.1+dfsg1-3ubuntu4.8_amd64.deb ...
==> default: Unpacking libxml2-dev:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...
==> default: Selecting previously unselected package libxslt1-dev:amd64.
==> default: Preparing to unpack .../libxslt1-dev_1.1.28-2build1_amd64.deb ...
==> default: Unpacking libxslt1-dev:amd64 (1.1.28-2build1) ...
==> default: Selecting previously unselected package shtool.
==> default: Preparing to unpack .../shtool_2.0.8-6_all.deb ...
==> default: Unpacking shtool (2.0.8-6) ...
==> default: Selecting previously unselected package php5-dev.
==> default: Preparing to unpack .../php5-dev_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-dev (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package re2c.
==> default: Preparing to unpack .../re2c_0.13.5-1build2_amd64.deb ...
==> default: Unpacking re2c (0.13.5-1build2) ...
==> default: Selecting previously unselected package pkg-php-tools.
==> default: Preparing to unpack .../pkg-php-tools_1.11_all.deb ...
==> default: Unpacking pkg-php-tools (1.11) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for install-info (5.2.0.dfsg.1-2) ...
==> default: Setting up libcroco3:amd64 (0.6.8-2ubuntu1) ...
==> default: Setting up libunistring0:amd64 (0.9.3-5ubuntu3) ...
==> default: Setting up libgettextpo0:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libxslt1.1:amd64 (1.1.28-2build1) ...
==> default: Setting up m4 (1.4.17-2ubuntu1) ...
==> default: Setting up autoconf (2.69-6) ...
==> default: Setting up autotools-dev (20130810.1) ...
==> default: Setting up automake (1:1.14.1-2ubuntu1) ...
==> default: update-alternatives: 
==> default: using /usr/bin/automake-1.14 to provide /usr/bin/automake (automake) in auto mode
==> default: Setting up libbison-dev:amd64 (2:3.0.2.dfsg-2) ...
==> default: Setting up bison (2:3.0.2.dfsg-2) ...
==> default: update-alternatives: 
==> default: using /usr/bin/bison.yacc to provide /usr/bin/yacc (yacc) in auto mode
==> default: Setting up libstdc++-4.8-dev:amd64 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Setting up g++-4.8 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Setting up g++ (4:4.8.2-1ubuntu6) ...
==> default: update-alternatives: 
==> default: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
==> default: Setting up libdpkg-perl (1.17.5ubuntu5.7) ...
==> default: Setting up dpkg-dev (1.17.5ubuntu5.7) ...
==> default: Setting up build-essential (11.6ubuntu6) ...
==> default: Setting up gettext (0.18.3.1-1ubuntu3) ...
==> default: Setting up intltool-debian (0.35.0+20060710.1) ...
==> default: Setting up po-debconf (1.0.16+nmu2ubuntu1) ...
==> default: Setting up dh-apparmor (2.8.95~2430-0ubuntu5.3) ...
==> default: Setting up debhelper (9.20131227ubuntu1) ...
==> default: Setting up libalgorithm-diff-perl (1.19.02-3) ...
==> default: Setting up libalgorithm-diff-xs-perl (0.04-2build4) ...
==> default: Setting up libalgorithm-merge-perl (0.08-2) ...
==> default: Setting up libasprintf-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libbz2-dev:amd64 (1.0.6-5) ...
==> default: Setting up libfile-fcntllock-perl (0.14-2build1) ...
==> default: Setting up libgettextpo-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libltdl-dev:amd64 (2.4.2-1.7ubuntu1) ...
==> default: Setting up libsys-hostname-long-perl (1.4-3) ...
==> default: Setting up libmail-sendmail-perl (0.79.16-1) ...
==> default: Setting up libtinfo-dev:amd64 (5.9+20140118-1ubuntu1) ...
==> default: Setting up libreadline6-dev:amd64 (6.3-4ubuntu2) ...
==> default: Setting up libreadline-dev:amd64 (6.3-4ubuntu2) ...
==> default: Setting up zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...
==> default: Setting up libssl-dev:amd64 (1.0.1f-1ubuntu2.21) ...
==> default: Setting up libssl-doc (1.0.1f-1ubuntu2.21) ...
==> default: Setting up libtool (2.4.2-1.7ubuntu1) ...
==> default: Setting up libxml2-dev:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...
==> default: Setting up libxslt1-dev:amd64 (1.1.28-2build1) ...
==> default: Setting up shtool (2.0.8-6) ...
==> default: Setting up php5-dev (5.5.9+dfsg-1ubuntu4.20) ...
==> default: update-alternatives: 
==> default: using /usr/bin/php-config5 to provide /usr/bin/php-config (php-config) in auto mode
==> default: update-alternatives: 
==> default: using /usr/bin/phpize5 to provide /usr/bin/phpize (phpize) in auto mode
==> default: Setting up re2c (0.13.5-1build2) ...
==> default: Setting up pkg-php-tools (1.11) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libjpeg8 is already the newest version.
==> default: libjpeg8 set to manually installed.
==> default: libltdl-dev is already the newest version.
==> default: libltdl-dev set to manually installed.
==> default: libltdl7 is already the newest version.
==> default: libltdl7 set to manually installed.
==> default: libxpm4 is already the newest version.
==> default: libxpm4 set to manually installed.
==> default: libfreetype6 is already the newest version.
==> default: libfreetype6 set to manually installed.
==> default: libgd3 is already the newest version.
==> default: libgd3 set to manually installed.
==> default: libpng12-0 is already the newest version.
==> default: The following extra packages will be installed:
==> default:   libexpat1-dev libfontconfig1-dev libice-dev libjbig-dev libjpeg-turbo8-dev
==> default:   liblzma-dev libpthread-stubs0-dev libsm-dev libtiff5-dev libtiffxx5
==> default:   libvpx-dev libx11-dev libx11-doc libxau-dev libxcb1-dev libxdmcp-dev
==> default:   libxpm-dev libxt-dev pkg-config x11proto-core-dev x11proto-input-dev
==> default:   x11proto-kb-dev xorg-sgml-doctools xtrans-dev
==> default: Suggested packages:
==> default:   libice-doc liblzma-doc libsm-doc libxcb-doc libxt-doc
==> default: The following NEW packages will be installed:
==> default:   libexpat1-dev libfontconfig1-dev libfreetype6-dev libgd-dev libice-dev
==> default:   libjbig-dev libjpeg-dev libjpeg-turbo8-dev libjpeg8-dev liblzma-dev
==> default:   libpng12-dev libpthread-stubs0-dev libsm-dev libtiff5-dev libtiffxx5
==> default:   libvpx-dev libx11-dev libx11-doc libxau-dev libxcb1-dev libxdmcp-dev
==> default:   libxpm-dev libxt-dev pkg-config x11proto-core-dev x11proto-input-dev
==> default:   x11proto-kb-dev xorg-sgml-doctools xtrans-dev
==> default: 0 upgraded, 29 newly installed, 0 to remove and 5 not upgraded.
==> default: Need to get 7,204 kB of archives.
==> default: After this operation, 32.6 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libtiffxx5 amd64 4.0.3-7ubuntu0.4 [5,634 B]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libjbig-dev amd64 2.0-2ubuntu4.1 [6,268 B]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libexpat1-dev amd64 2.1.0-4ubuntu1.3 [115 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libpng12-dev amd64 1.2.50-1ubuntu2.14.04.2 [206 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libfreetype6-dev amd64 2.5.2-1ubuntu2.5 [621 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main pkg-config amd64 0.26-1ubuntu4 [40.9 kB]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libfontconfig1-dev amd64 2.11.0-0ubuntu4.2 [665 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg-turbo8-dev amd64 1.3.0-0ubuntu2 [242 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg8-dev amd64 8c-2ubuntu8 [1,552 B]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg-dev amd64 8c-2ubuntu8 [1,546 B]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty/main xorg-sgml-doctools all 1:1.11-1 [12.9 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty-updates/main x11proto-core-dev all 7.0.26-1~ubuntu2 [700 kB]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty/main libxau-dev amd64 1:1.0.8-1 [11.1 kB]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty/main libxdmcp-dev amd64 1:1.1.1-1 [26.9 kB]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty/main x11proto-input-dev all 2.3-1 [139 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/main x11proto-kb-dev all 1.0.6-2 [269 kB]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty-updates/main xtrans-dev all 1.3.5-1~ubuntu14.04.1 [70.3 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/main libpthread-stubs0-dev amd64 0.3-4 [4,068 B]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/main libxcb1-dev amd64 1.10-2ubuntu1 [76.6 kB]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty/main libx11-dev amd64 2:1.6.2-1ubuntu2 [629 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/main libxpm-dev amd64 1:3.5.10-1 [94.2 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/main libice-dev amd64 2:1.0.8-2 [57.6 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/main libsm-dev amd64 2:1.2.1-2 [19.9 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/main libxt-dev amd64 1:1.1.4-1 [455 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty/main libvpx-dev amd64 1.3.0-2 [635 kB]
==> default: Get:26 http://archive.ubuntu.com/ubuntu/ trusty/main liblzma-dev amd64 5.1.1alpha+20120614-2ubuntu2 [137 kB]
==> default: Get:27 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libtiff5-dev amd64 4.0.3-7ubuntu0.4 [263 kB]
==> default: Get:28 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgd-dev amd64 2.1.0-3ubuntu0.5 [250 kB]
==> default: Get:29 http://archive.ubuntu.com/ubuntu/ trusty/main libx11-doc all 2:1.6.2-1ubuntu2 [1,448 kB]
==> default: Fetched 7,204 kB in 16s (444 kB/s)
==> default: Selecting previously unselected package libtiffxx5:amd64.
==> default: (Reading database ... 69684 files and directories currently installed.)
==> default: Preparing to unpack .../libtiffxx5_4.0.3-7ubuntu0.4_amd64.deb ...
==> default: Unpacking libtiffxx5:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Selecting previously unselected package libjbig-dev:amd64.
==> default: Preparing to unpack .../libjbig-dev_2.0-2ubuntu4.1_amd64.deb ...
==> default: Unpacking libjbig-dev:amd64 (2.0-2ubuntu4.1) ...
==> default: Selecting previously unselected package libexpat1-dev:amd64.
==> default: Preparing to unpack .../libexpat1-dev_2.1.0-4ubuntu1.3_amd64.deb ...
==> default: Unpacking libexpat1-dev:amd64 (2.1.0-4ubuntu1.3) ...
==> default: Selecting previously unselected package libpng12-dev.
==> default: Preparing to unpack .../libpng12-dev_1.2.50-1ubuntu2.14.04.2_amd64.deb ...
==> default: Unpacking libpng12-dev (1.2.50-1ubuntu2.14.04.2) ...
==> default: Selecting previously unselected package libfreetype6-dev.
==> default: Preparing to unpack .../libfreetype6-dev_2.5.2-1ubuntu2.5_amd64.deb ...
==> default: Unpacking libfreetype6-dev (2.5.2-1ubuntu2.5) ...
==> default: Selecting previously unselected package pkg-config.
==> default: Preparing to unpack .../pkg-config_0.26-1ubuntu4_amd64.deb ...
==> default: Unpacking pkg-config (0.26-1ubuntu4) ...
==> default: Selecting previously unselected package libfontconfig1-dev.
==> default: Preparing to unpack .../libfontconfig1-dev_2.11.0-0ubuntu4.2_amd64.deb ...
==> default: Unpacking libfontconfig1-dev (2.11.0-0ubuntu4.2) ...
==> default: Selecting previously unselected package libjpeg-turbo8-dev:amd64.
==> default: Preparing to unpack .../libjpeg-turbo8-dev_1.3.0-0ubuntu2_amd64.deb ...
==> default: Unpacking libjpeg-turbo8-dev:amd64 (1.3.0-0ubuntu2) ...
==> default: Selecting previously unselected package libjpeg8-dev:amd64.
==> default: Preparing to unpack .../libjpeg8-dev_8c-2ubuntu8_amd64.deb ...
==> default: Unpacking libjpeg8-dev:amd64 (8c-2ubuntu8) ...
==> default: Selecting previously unselected package libjpeg-dev:amd64.
==> default: Preparing to unpack .../libjpeg-dev_8c-2ubuntu8_amd64.deb ...
==> default: Unpacking libjpeg-dev:amd64 (8c-2ubuntu8) ...
==> default: Selecting previously unselected package xorg-sgml-doctools.
==> default: Preparing to unpack .../xorg-sgml-doctools_1%3a1.11-1_all.deb ...
==> default: Unpacking xorg-sgml-doctools (1:1.11-1) ...
==> default: Selecting previously unselected package x11proto-core-dev.
==> default: Preparing to unpack .../x11proto-core-dev_7.0.26-1~ubuntu2_all.deb ...
==> default: Unpacking x11proto-core-dev (7.0.26-1~ubuntu2) ...
==> default: Selecting previously unselected package libxau-dev:amd64.
==> default: Preparing to unpack .../libxau-dev_1%3a1.0.8-1_amd64.deb ...
==> default: Unpacking libxau-dev:amd64 (1:1.0.8-1) ...
==> default: Selecting previously unselected package libxdmcp-dev:amd64.
==> default: Preparing to unpack .../libxdmcp-dev_1%3a1.1.1-1_amd64.deb ...
==> default: Unpacking libxdmcp-dev:amd64 (1:1.1.1-1) ...
==> default: Selecting previously unselected package x11proto-input-dev.
==> default: Preparing to unpack .../x11proto-input-dev_2.3-1_all.deb ...
==> default: Unpacking x11proto-input-dev (2.3-1) ...
==> default: Selecting previously unselected package x11proto-kb-dev.
==> default: Preparing to unpack .../x11proto-kb-dev_1.0.6-2_all.deb ...
==> default: Unpacking x11proto-kb-dev (1.0.6-2) ...
==> default: Selecting previously unselected package xtrans-dev.
==> default: Preparing to unpack .../xtrans-dev_1.3.5-1~ubuntu14.04.1_all.deb ...
==> default: Unpacking xtrans-dev (1.3.5-1~ubuntu14.04.1) ...
==> default: Selecting previously unselected package libpthread-stubs0-dev:amd64.
==> default: Preparing to unpack .../libpthread-stubs0-dev_0.3-4_amd64.deb ...
==> default: Unpacking libpthread-stubs0-dev:amd64 (0.3-4) ...
==> default: Selecting previously unselected package libxcb1-dev:amd64.
==> default: Preparing to unpack .../libxcb1-dev_1.10-2ubuntu1_amd64.deb ...
==> default: Unpacking libxcb1-dev:amd64 (1.10-2ubuntu1) ...
==> default: Selecting previously unselected package libx11-dev:amd64.
==> default: Preparing to unpack .../libx11-dev_2%3a1.6.2-1ubuntu2_amd64.deb ...
==> default: Unpacking libx11-dev:amd64 (2:1.6.2-1ubuntu2) ...
==> default: Selecting previously unselected package libxpm-dev:amd64.
==> default: Preparing to unpack .../libxpm-dev_1%3a3.5.10-1_amd64.deb ...
==> default: Unpacking libxpm-dev:amd64 (1:3.5.10-1) ...
==> default: Selecting previously unselected package libice-dev:amd64.
==> default: Preparing to unpack .../libice-dev_2%3a1.0.8-2_amd64.deb ...
==> default: Unpacking libice-dev:amd64 (2:1.0.8-2) ...
==> default: Selecting previously unselected package libsm-dev:amd64.
==> default: Preparing to unpack .../libsm-dev_2%3a1.2.1-2_amd64.deb ...
==> default: Unpacking libsm-dev:amd64 (2:1.2.1-2) ...
==> default: Selecting previously unselected package libxt-dev:amd64.
==> default: Preparing to unpack .../libxt-dev_1%3a1.1.4-1_amd64.deb ...
==> default: Unpacking libxt-dev:amd64 (1:1.1.4-1) ...
==> default: Selecting previously unselected package libvpx-dev:amd64.
==> default: Preparing to unpack .../libvpx-dev_1.3.0-2_amd64.deb ...
==> default: Unpacking libvpx-dev:amd64 (1.3.0-2) ...
==> default: Selecting previously unselected package liblzma-dev:amd64.
==> default: Preparing to unpack .../liblzma-dev_5.1.1alpha+20120614-2ubuntu2_amd64.deb ...
==> default: Unpacking liblzma-dev:amd64 (5.1.1alpha+20120614-2ubuntu2) ...
==> default: Selecting previously unselected package libtiff5-dev:amd64.
==> default: Preparing to unpack .../libtiff5-dev_4.0.3-7ubuntu0.4_amd64.deb ...
==> default: Unpacking libtiff5-dev:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Selecting previously unselected package libgd-dev:amd64.
==> default: Preparing to unpack .../libgd-dev_2.1.0-3ubuntu0.5_amd64.deb ...
==> default: Unpacking libgd-dev:amd64 (2.1.0-3ubuntu0.5) ...
==> default: Selecting previously unselected package libx11-doc.
==> default: Preparing to unpack .../libx11-doc_2%3a1.6.2-1ubuntu2_all.deb ...
==> default: Unpacking libx11-doc (2:1.6.2-1ubuntu2) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libtiffxx5:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Setting up libjbig-dev:amd64 (2.0-2ubuntu4.1) ...
==> default: Setting up libexpat1-dev:amd64 (2.1.0-4ubuntu1.3) ...
==> default: Setting up libpng12-dev (1.2.50-1ubuntu2.14.04.2) ...
==> default: Setting up libfreetype6-dev (2.5.2-1ubuntu2.5) ...
==> default: Setting up pkg-config (0.26-1ubuntu4) ...
==> default: Setting up libfontconfig1-dev (2.11.0-0ubuntu4.2) ...
==> default: Setting up libjpeg-turbo8-dev:amd64 (1.3.0-0ubuntu2) ...
==> default: Setting up libjpeg8-dev:amd64 (8c-2ubuntu8) ...
==> default: Setting up libjpeg-dev:amd64 (8c-2ubuntu8) ...
==> default: Setting up xorg-sgml-doctools (1:1.11-1) ...
==> default: Setting up x11proto-core-dev (7.0.26-1~ubuntu2) ...
==> default: Setting up libxau-dev:amd64 (1:1.0.8-1) ...
==> default: Setting up libxdmcp-dev:amd64 (1:1.1.1-1) ...
==> default: Setting up x11proto-input-dev (2.3-1) ...
==> default: Setting up x11proto-kb-dev (1.0.6-2) ...
==> default: Setting up xtrans-dev (1.3.5-1~ubuntu14.04.1) ...
==> default: Setting up libpthread-stubs0-dev:amd64 (0.3-4) ...
==> default: Setting up libxcb1-dev:amd64 (1.10-2ubuntu1) ...
==> default: Setting up libx11-dev:amd64 (2:1.6.2-1ubuntu2) ...
==> default: Setting up libxpm-dev:amd64 (1:3.5.10-1) ...
==> default: Setting up libice-dev:amd64 (2:1.0.8-2) ...
==> default: Setting up libsm-dev:amd64 (2:1.2.1-2) ...
==> default: Setting up libxt-dev:amd64 (1:1.1.4-1) ...
==> default: Setting up libvpx-dev:amd64 (1.3.0-2) ...
==> default: Setting up liblzma-dev:amd64 (5.1.1alpha+20120614-2ubuntu2) ...
==> default: Setting up libtiff5-dev:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Setting up libgd-dev:amd64 (2.1.0-3ubuntu0.5) ...
==> default: Setting up libx11-doc (2:1.6.2-1ubuntu2) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libssl-dev is already the newest version.
==> default: libssl-dev set to manually installed.
==> default: openssl is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: gettext is already the newest version.
==> default: gettext set to manually installed.
==> default: libgettextpo-dev is already the newest version.
==> default: libgettextpo-dev set to manually installed.
==> default: libgettextpo0 is already the newest version.
==> default: libgettextpo0 set to manually installed.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: php5-cli is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   libmcrypt4
==> default: Suggested packages:
==> default:   mcrypt
==> default: The following NEW packages will be installed:
==> default:   libmcrypt-dev libmcrypt4
==> default: 0 upgraded, 2 newly installed, 0 to remove and 5 not upgraded.
==> default: Need to get 145 kB of archives.
==> default: After this operation, 655 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/universe libmcrypt4 amd64 2.5.8-3.1ubuntu1 [61.9 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/universe libmcrypt-dev amd64 2.5.8-3.1ubuntu1 [83.1 kB]
==> default: Fetched 145 kB in 2s (49.2 kB/s)
==> default: Selecting previously unselected package libmcrypt4.
==> default: (Reading database ... 71933 files and directories currently installed.)
==> default: Preparing to unpack .../libmcrypt4_2.5.8-3.1ubuntu1_amd64.deb ...
==> default: Unpacking libmcrypt4 (2.5.8-3.1ubuntu1) ...
==> default: Selecting previously unselected package libmcrypt-dev.
==> default: Preparing to unpack .../libmcrypt-dev_2.5.8-3.1ubuntu1_amd64.deb ...
==> default: Unpacking libmcrypt-dev (2.5.8-3.1ubuntu1) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libmcrypt4 (2.5.8-3.1ubuntu1) ...
==> default: Setting up libmcrypt-dev (2.5.8-3.1ubuntu1) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libreadline-dev is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.
==> default: /home/vagrant
==> default: # WARNING: curl extension might be required for fetching data.
==> default: Using root: /root/.phpbrew
==> default: Initialization successfully finished!
==> default: <=====================================================>
==> default: Phpbrew environment is initialized, required directories are created under
==> default: 
==> default:     /root/.phpbrew
==> default: 
==> default: Paste the following line(s) to the end of your ~/.bashrc and start a
==> default: new shell, phpbrew should be up and fully functional from there:
==> default: 
==> default:     source /root/.phpbrew/bashrc
==> default: 
==> default: To enable PHP version info in your shell prompt, please set PHPBREW_SET_PROMPT=1
==> default: in your `~/.bashrc` before you source `~/.phpbrew/bashrc`
==> default: 
==> default:     export PHPBREW_SET_PROMPT=1
==> default: 
==> default: To enable .phpbrewrc file searching, please export the following variable:
==> default: 
==> default:     export PHPBREW_RC_ENABLE=1
==> default: 
==> default: 
==> default: For further instructions, simply run `phpbrew` to see the help message.
==> default: 
==> default: Enjoy phpbrew at $HOME!!
==> default: <=====================================================>
==> default: # WARNING: curl extension might be required for fetching data.
==> default: ===> Fetching release list...
==> default: Downloading https://secure.php.net/releases/index.php?json&version=7&max=100 via php stream
==> default: Downloading https://secure.php.net/releases/index.php?json&version=5&max=100 via php stream
==> default: 7.1: 7.1.0 ...
==> default: 7.0: 7.0.14, 7.0.13, 7.0.12, 7.0.11, 7.0.10, 7.0.9, 7.0.8, 7.0.7 ...
==> default: 5.6: 5.6.29, 5.6.28, 5.6.27, 5.6.26, 5.6.25, 5.6.24, 5.6.23, 5.6.22 ...
==> default: 5.5: 5.5.38, 5.5.37, 5.5.36, 5.5.35, 5.5.34, 5.5.33, 5.5.32, 5.5.31 ...
==> default: 5.4: 5.4.45, 5.4.44, 5.4.43, 5.4.42, 5.4.41, 5.4.40, 5.4.39, 5.4.38 ...
==> default: # WARNING: curl extension might be required for fetching data.
==> default: ===> Fetching release list...
==> default: Downloading https://secure.php.net/releases/index.php?json&version=7&max=100 via php stream
==> default: Downloading https://secure.php.net/releases/index.php?json&version=5&max=100 via php stream
==> default: 7.1: 1 releases
==> default: 7.0: 15 releases
==> default: 5.6: 30 releases
==> default: 5.5: 39 releases
==> default: 5.4: 31 releases
==> default: ===> Done
==> default: # WARNING: curl extension might be required for fetching data.
==> default: *WARNING* You're runing phpbrew as root/sudo. Unless you're going to install
==> default: system-wide phpbrew or this might cause problems.
==> default: ===> phpbrew will now build 5.4.34
==> default: ===> Loading and resolving variants...
==> default: Downloading http://www.php.net/get/php-5.4.34.tar.bz2/from/this/mirror via php stream
==> default: ===> Extracting /root/.phpbrew/distfiles/php-5.4.34.tar.bz2 to /root/.phpbrew/build/tmp.1483589580/php-5.4.34
==> default: ===> Moving /root/.phpbrew/build/tmp.1483589580/php-5.4.34 to /root/.phpbrew/build/php-5.4.34
==> default: ===> Checking patches...
==> default: Checking patch for replace apache php module name with custom version name
==> default: ===> Configuring 5.4.34...
==> default: 
==> default: Use tail command to see what's going on:
==> default:    $ tail -F /root/.phpbrew/build/php-5.4.34/build.log
==> default: ===> Checking patches...
==> default: Checking patch for php5.3.29 multi-sapi patch.
==> default: Checking patch for php5.3.x on 64bit machine when intl is enabled.
==> default: Checking patch for openssl dso linking patch
==> default: ===> Building...
==> default: Build finished: 3.1 minutes.
==> default: Installing...
==> default: ---> Creating php-fpm.conf
==> default: ---> Creating php.ini
==> default: ---> Copying /root/.phpbrew/build/php-5.4.34/php.ini-development 
==> default: ---> Found date.timezone is not set, patching...
==> default: Congratulations! Now you have PHP with 5.4.34 as php-5.4.34
==> default: 
==> default: * To configure your installed PHP further, you can edit the config file at
==> default:     /root/.phpbrew/php/php-5.4.34/etc/php.ini
==> default: 
==> default: * WARNING:
==> default:   You haven't setup your .bashrc file to load phpbrew shell script yet!
==> default:   Please run 'phpbrew init' to see the steps!
==> default: 
==> default: To use the newly built PHP, try the line(s) below:
==> default: 
==> default:     $ phpbrew use php-5.4.34
==> default: 
==> default: Or you can use switch command to switch your default php to php-5.4.34:
==> default: 
==> default:     $ phpbrew switch php-5.4.34
==> default: 
==> default: Enjoy!
==> default: # WARNING: curl extension might be required for fetching data.
==> default: Invalid argument php-5.4.34
==> default: # WARNING: curl extension might be required for fetching data.
==> default: Error: PHPBREW_PHP environment variable is not defined.
==> default:   This extension command requires you specify a PHP version from your build list.
==> default:   And it looks like you haven't switched to a version from the builds that were built with PHPBrew.
==> default: Suggestion: Please install at least one PHP with your prefered version and switch to it.
==> default: All settings correct for using Composer
==> default: Downloading...
==> default: 
==> default: Composer (version 1.3.0) successfully installed to: /home/vagrant/project/integration-tests/composer.phar
==> default: Use it: php composer.phar
==> default: Do not run Composer as root/super user! See https://getcomposer.org/root for details
==> default: Loading composer repositories with package information
==> default: Installing dependencies (including require-dev) from lock file
==> default: Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.
==> default: Nothing to install or update
==> default: Generating autoload files
Welcome to Ubuntu 14.04.5 LTS (GNU/Linux 3.13.0-105-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Thu Jan  5 04:10:38 UTC 2017

  System load:  0.84              Processes:           82
  Usage of /:   3.6% of 39.34GB   Users logged in:     0
  Memory usage: 6%                IP address for eth0: 10.0.2.15
  Swap usage:   0%

  Graph this data and manage this system at:
    https://landscape.canonical.com/

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

0 packages can be updated.
0 updates are security updates.

New release '16.04.1 LTS' available.
Run 'do-release-upgrade' to upgrade to it.


-bash: /root/.phpbrew/bashrc: Permission denied
vagrant@vagrant-ubuntu-trusty-64:~$ cd /home/vagrant/project/integration-tests/
vagrant@vagrant-ubuntu-trusty-64:~/project/integration-tests$ ./composer.phar update
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 0 installs, 0 updates, 2 removals
  - Removing monolog/monolog (1.21.0)
  - Removing psr/log (1.0.2)
Writing lock file
Generating autoload files
vagrant@vagrant-ubuntu-trusty-64:~/project/integration-tests$ vendor/bin/phpunit LDDFeatureRequesterTest.php 
PHPUnit 4.3.5 by Sebastian Bergmann.

PHP Fatal error:  Class 'Monolog\Logger' not found in /home/vagrant/project/src/LaunchDarkly/LDClient.php on line 78
PHP Stack trace:
PHP   1. {main}() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/phpunit:56
PHP   3. PHPUnit_TextUI_Command->run() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/TextUI/Command.php:138
PHP   4. PHPUnit_TextUI_TestRunner->doRun() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/TextUI/Command.php:186
PHP   5. PHPUnit_Framework_TestSuite->run() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:423
PHP   6. PHPUnit_Framework_TestCase->run() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/Framework/TestSuite.php:751
PHP   7. PHPUnit_Framework_TestResult->run() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/Framework/TestCase.php:711
PHP   8. PHPUnit_Framework_TestCase->runBare() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/Framework/TestResult.php:643
PHP   9. PHPUnit_Framework_TestCase->runTest() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/Framework/TestCase.php:775
PHP  10. ReflectionMethod->invokeArgs() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/Framework/TestCase.php:905
PHP  11. LaunchDarkly\Tests\LDDFeatureRetrieverTest->testGet() /home/vagrant/project/integration-tests/vendor/phpunit/phpunit/src/Framework/TestCase.php:905
PHP  12. LaunchDarkly\LDClient->__construct() /home/vagrant/project/integration-tests/LDDFeatureRequesterTest.php:16
vagrant@vagrant-ubuntu-trusty-64:~/project/integration-tests$ ./composer.phar require monolog/monolog
Using version ^1.22 for monolog/monolog
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 2 installs, 0 updates, 0 removals
  - Installing psr/log (1.0.2) Downloading: 100%         
  - Installing monolog/monolog (1.22.0) Downloading: 100%         
monolog/monolog suggests installing aws/aws-sdk-php (Allow sending log messages to AWS services like DynamoDB)
monolog/monolog suggests installing doctrine/couchdb (Allow sending log messages to a CouchDB server)
monolog/monolog suggests installing ext-amqp (Allow sending log messages to an AMQP server (1.0+ required))
monolog/monolog suggests installing ext-mongo (Allow sending log messages to a MongoDB server)
monolog/monolog suggests installing graylog2/gelf-php (Allow sending log messages to a GrayLog2 server)
monolog/monolog suggests installing mongodb/mongodb (Allow sending log messages to a MongoDB server via PHP Driver)
monolog/monolog suggests installing php-amqplib/php-amqplib (Allow sending log messages to an AMQP server using php-amqplib)
monolog/monolog suggests installing php-console/php-console (Allow sending log messages to Google Chrome)
monolog/monolog suggests installing rollbar/rollbar (Allow sending log messages to Rollbar)
monolog/monolog suggests installing ruflin/elastica (Allow sending log messages to an Elastic Search server)
monolog/monolog suggests installing sentry/sentry (Allow sending log messages to a Sentry server)
Writing lock file
Generating autoload files
vagrant@vagrant-ubuntu-trusty-64:~/project/integration-tests$ vendor/bin/phpunit LDDFeatureRequesterTest.php 
PHPUnit 4.3.5 by Sebastian Bergmann.

[2017-01-05 04:28:25] LaunchDarkly.WARNING: LDDFeatureRequester: Attempted to get missing feature with key: foo [] []
[2017-01-05 04:28:26] LaunchDarkly.ERROR: Caught Undefined index: prerequisites  /home/vagrant/project/src/LaunchDarkly/FeatureFlag.php:60 /home/vagrant/project/src/LaunchDarkly/FeatureFlag.php:72 /home/vagrant/project/src/LaunchDarkly/LDDFeatureRequester.php:61 /home/vagrant/project/src/LaunchDarkly/LDClient.php:122 /home/vagrant/project/integration-tests/LDDFeatureRequesterTest.php:23  [] []
F[2017-01-05 04:28:26] LaunchDarkly.WARNING: LDDFeatureRequester: Attempted to get missing feature with key: foo [] []
[2017-01-05 04:28:26] LaunchDarkly.ERROR: Caught Undefined index: prerequisites  /home/vagrant/project/src/LaunchDarkly/FeatureFlag.php:60 /home/vagrant/project/src/LaunchDarkly/FeatureFlag.php:72 /home/vagrant/project/src/LaunchDarkly/LDDFeatureRequester.php:61 /home/vagrant/project/src/LaunchDarkly/LDClient.php:122 /home/vagrant/project/integration-tests/LDDFeatureRequesterTest.php:39  [] []
F

Time: 326 ms, Memory: 5.25MB

There were 2 failures:

1) LaunchDarkly\Tests\LDDFeatureRetrieverTest::testGet
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'bar'
+'jim'

/home/vagrant/project/integration-tests/LDDFeatureRequesterTest.php:23

2) LaunchDarkly\Tests\LDDFeatureRetrieverTest::testGetApc
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'bar'
+'jim'

/home/vagrant/project/integration-tests/LDDFeatureRequesterTest.php:39

FAILURES!
Tests: 2, Assertions: 4, Failures: 2.
```

due to this provision error `-bash: /root/.phpbrew/bashrc: Permission denied`, i have a feeling that my provisioner didn't get past this line:
https://github.com/launchdarkly/php-client/blob/master/integration-tests/bootstrap.sh#L51

additionally, i think `\LaunchDarkly\Tests\LDDFeatureRetrieverTest::gen_feature` is out-of-date. i updated the generated data in my [TravisCI integration test pull request](https://github.com/launchdarkly/php-client/pull/48/files#diff-edf8b17c5e03d7dbead8517c4d3d3202R58), but i'm wondering if maybe i'm just not doing something right. any ideas?