### PR TITLE
Update provisioner

### DIFF
--- a/integration-tests/LDDFeatureRequesterTest.php
+++ b/integration-tests/LDDFeatureRequesterTest.php
@@ -47,19 +47,54 @@ class LDDFeatureRetrieverTest extends \PHPUnit_Framework_TestCase {
     }
 
     private function gen_feature($key, $val) {
-        $data = <<<EOF
-           {"name": "Feature $key", "key": "$key", "kind": "flag", "salt": "Zm9v", "on": true,
-            "variations": [{"value": "$val", "weight": 100,
-                            "targets": [{"attribute": "key", "op": "in", "values": []}],
-                            "userTarget": {"attribute": "key", "op": "in", "values": []}},
-                           {"value": false, "weight": 0,
-                            "targets": [{"attribute": "key", "op": "in", "values": []}],
-                            "userTarget": {"attribute": "key", "op": "in", "values": []}}],
-            "commitDate": "2015-09-08T21:24:16.712Z",
-            "creationDate": "2015-09-08T21:06:16.527Z",
-            "version": 4}
-EOF;
-         return $data;
+        $data = [
+            'name' => 'Feature ' . $key,
+            'key' => $key,
+            'kind' => 'flag',
+            'salt' => 'Zm9v',
+            'on' => true,
+            'variations' => [
+                $val,
+                false,
+            ],
+            'commitDate' => '2015-09-08T21:24:16.712Z',
+            'creationDate' => '2015-09-08T21:06:16.527Z',
+            'version' => 4,
+            'prerequisites' => [],
+            'targets' => [
+                [
+                    'values' => [
+                        $val,
+                    ],
+                    'variation' => 0,
+                ],
+                [
+                    'values' => [
+                        false,
+                    ],
+                    'variation' => 1,
+                ],
+            ],
+            'rules' => [],
+            'fallthrough' => [
+                'rollout' => [
+                    'variations' => [
+                        [
+                            'variation' => 0,
+                            'weight' => 95000,
+                        ],
+                        [
+                            'variation' => 1,
+                            'weight' => 5000,
+                        ],
+                    ],
+                ],
+            ],
+            'offVariation' => null,
+            'deleted' => false,
+        ];
+        
+        return \json_encode($data);
     }
 
 }

--- a/integration-tests/Vagrantfile
+++ b/integration-tests/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "https://vagrantcloud.com/ubuntu/boxes/trusty64"
 
   config.vm.provision :shell, path: "bootstrap.sh"
+  config.vm.provision :shell, path: "bootstrap.user.sh", privileged: false
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,

--- a/integration-tests/bootstrap.sh
+++ b/integration-tests/bootstrap.sh
@@ -35,25 +35,3 @@ cat <<EOF > /home/vagrant/.vimrc
 set tabstop=4
 EOF
 chown vagrant.vagrant /home/vagrant/.vimrc
-
-su - vagrant
-cd ~vagrant
-pwd
-curl -s -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
-chmod +x phpbrew
-sudo mv phpbrew /usr/bin/phpbrew
-phpbrew init
-phpbrew known --update
-phpbrew update
-phpbrew install 5.4.34 +default
-
-echo "source $HOME/.phpbrew/bashrc" >> /home/vagrant/.bashrc
-source $HOME/.bashrc
-phpbrew switch php-5.4.34
-phpbrew ext install apc
-echo "apc.enable_cli = 1" >> ~/.phpbrew/php/php-5.4.34/etc/php.ini
-
-
-cd /home/vagrant/project/integration-tests
-curl -sS https://getcomposer.org/installer | php
-php composer.phar install

--- a/integration-tests/bootstrap.user.sh
+++ b/integration-tests/bootstrap.user.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo
+echo "install phpbrew and php54"
+cd ~
+curl -s -L -O https://github.com/phpbrew/phpbrew/raw/master/phpbrew
+chmod +x phpbrew
+sudo mv phpbrew /usr/bin/phpbrew
+phpbrew init
+phpbrew known --update
+phpbrew update
+phpbrew install 5.4.34 +default
+
+echo
+echo "switch php54"
+echo "source $HOME/.phpbrew/bashrc" >> /home/vagrant/.bashrc
+source $HOME/.phpbrew/bashrc
+phpbrew switch 5.4.34
+
+echo
+echo "install php54-apc"
+phpbrew ext install apc
+echo "apc.enable_cli = 1" >> ~/.phpbrew/php/php-5.4.34/etc/php.ini
+echo "date.timezone =UTC" >> ~/.phpbrew/php/php-5.4.34/etc/php.ini
+
+echo
+echo "update project dependencies"
+cd /home/vagrant/project/integration-tests
+curl -sS https://getcomposer.org/installer | php
+php composer.phar update

--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -88,7 +88,7 @@ class LDClient {
             $featureRequesterClass = '\\LaunchDarkly\\GuzzleFeatureRequester';
         }
 
-        if (!is_a($featureRequesterClass, FeatureRequester::class, true)) {
+        if (!is_a($featureRequesterClass, '\LaunchDarkly\FeatureRequester', true)) {
             throw new \InvalidArgumentException;
         }
         $this->_featureRequester = new $featureRequesterClass($this->_baseUri, $sdkKey, $options);


### PR DESCRIPTION
this request is based on https://github.com/launchdarkly/php-client/pull/56

i've documented the `before` and `after` provisioner commands and output at the end of this request summary.

provisioning from `launchdarkly/master`|`abacaphiliac/update-integration-test-feature-generator` ends in a line that hints to a problem:
```
-bash: /root/.phpbrew/bashrc: Permission denied
```

when you run `vagrant ssh` and `php -v` you'll see that the system php55 is linked, not php54 which was installed by phpbrew. what i've discovered is that the `source` line echoed into the `vagrant` user `bashrc` to bootstrap `phpbrew` for linking isn't able to run when the user logs in, meaning that a dev needs to know to run `source` and `switch` on their own. this is not obvious.

this change separates root bootstrap from user bootstrap. system dependencies are installed by root. i used the old bootstrap's Switch User line as a cutoff for the user bootstrap, where phpbrew and php54 are installed and switched. the user bootstrap is run in non-privileged mode from the Vagrantfile after the root bootstrap. this ensures that phpbrew is installed in the correct location with the correct permissions, allowing a dev to be shelled in with php54 linked instead of php55 by simply running `vagrant ssh`.

additionally, it appears that the master provisioner fails too early and does not actually install APC for php54. i had to update the switch command from `phpbrew switch php-5.4.34` to `phpbrew switch 5.4.34`, as `php-5.4.34` is invalid.

i will demonstrate the failures and fixes now.

# initial provision (from #56)
```
10:35 $ 
✔ ~/github.com/launchdarkly/php-client/integration-tests [update-integration-test-feature-generator ↑·1|✔] 
10:35 $ rm -rf composer.lock vendor/
✔ ~/github.com/launchdarkly/php-client/integration-tests [update-integration-test-feature-generator ↑·1|✔] 
10:35 $ vagrant destroy && vagrant up && vagrant ssh
    default: Are you sure you want to destroy the 'default' VM? [y/N] y
==> default: Forcing shutdown of VM...
==> default: Destroying VM and associated drives...
==> default: [vagrant-hostsupdater] Removing hosts
==> default: Running cleanup tasks for 'shell' provisioner...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/trusty64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/trusty64' is up to date...
==> default: A newer version of the box 'ubuntu/trusty64' is available! You currently
==> default: have version '20161214.0.0'. The latest is version '20170110.0.0'. Run
==> default: `vagrant box update` to update.
==> default: Setting the name of the VM: integration-tests_default_1484674579419_95975
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 => 2200 (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 4.3.36
    default: VirtualBox Version: 5.0
==> default: [vagrant-hostsupdater] Checking for host entries
==> default: Mounting shared folders...
    default: /vagrant => /Users/tyounger/github.com/launchdarkly/php-client/integration-tests
    default: /home/vagrant/project => /Users/tyounger/github.com/launchdarkly/php-client
==> default: Running provisioner: shell...
    default: Running: /var/folders/gk/qkjjk8zs32v4jrg3k3xgf7h5y_y_66/T/vagrant-shell20170117-63360-yl0rfc.sh
==> default: stdin: is not a tty
==> default: Get:1 http://security.ubuntu.com trusty-security InRelease [65.9 kB]
==> default: Ign http://archive.ubuntu.com trusty InRelease
==> default: Get:2 http://security.ubuntu.com trusty-security/main Sources [123 kB]
==> default: Get:3 http://archive.ubuntu.com trusty-updates InRelease [65.9 kB]
==> default: Get:4 http://security.ubuntu.com trusty-security/universe Sources [47.3 kB]
==> default: Get:5 http://security.ubuntu.com trusty-security/main amd64 Packages [573 kB]
==> default: Get:6 http://security.ubuntu.com trusty-security/universe amd64 Packages [148 kB]
==> default: Get:7 http://archive.ubuntu.com trusty-backports InRelease [65.9 kB]
==> default: Get:8 http://security.ubuntu.com trusty-security/main Translation-en [317 kB]
==> default: Get:9 http://security.ubuntu.com trusty-security/universe Translation-en [87.2 kB]
==> default: Hit http://archive.ubuntu.com trusty Release.gpg
==> default: Get:10 http://archive.ubuntu.com trusty-updates/main Sources [388 kB]
==> default: Get:11 http://archive.ubuntu.com trusty-updates/restricted Sources [5,888 B]
==> default: Get:12 http://archive.ubuntu.com trusty-updates/universe Sources [171 kB]
==> default: Get:13 http://archive.ubuntu.com trusty-updates/multiverse Sources [7,535 B]
==> default: Get:14 http://archive.ubuntu.com trusty-updates/main amd64 Packages [938 kB]
==> default: Get:15 http://archive.ubuntu.com trusty-updates/restricted amd64 Packages [16.4 kB]
==> default: Get:16 http://archive.ubuntu.com trusty-updates/universe amd64 Packages [392 kB]
==> default: Get:17 http://archive.ubuntu.com trusty-updates/multiverse amd64 Packages [14.0 kB]
==> default: Get:18 http://archive.ubuntu.com trusty-updates/main Translation-en [460 kB]
==> default: Get:19 http://archive.ubuntu.com trusty-updates/multiverse Translation-en [7,340 B]
==> default: Get:20 http://archive.ubuntu.com trusty-updates/restricted Translation-en [3,842 B]
==> default: Get:21 http://archive.ubuntu.com trusty-updates/universe Translation-en [208 kB]
==> default: Get:22 http://archive.ubuntu.com trusty-backports/main Sources [9,636 B]
==> default: Get:23 http://archive.ubuntu.com trusty-backports/restricted Sources [28 B]
==> default: Get:24 http://archive.ubuntu.com trusty-backports/universe Sources [35.3 kB]
==> default: Get:25 http://archive.ubuntu.com trusty-backports/multiverse Sources [1,898 B]
==> default: Get:26 http://archive.ubuntu.com trusty-backports/main amd64 Packages [13.3 kB]
==> default: Get:27 http://archive.ubuntu.com trusty-backports/restricted amd64 Packages [28 B]
==> default: Get:28 http://archive.ubuntu.com trusty-backports/universe amd64 Packages [43.2 kB]
==> default: Get:29 http://archive.ubuntu.com trusty-backports/multiverse amd64 Packages [1,571 B]
==> default: Get:30 http://archive.ubuntu.com trusty-backports/main Translation-en [7,493 B]
==> default: Get:31 http://archive.ubuntu.com trusty-backports/multiverse Translation-en [1,215 B]
==> default: Get:32 http://archive.ubuntu.com trusty-backports/restricted Translation-en [28 B]
==> default: Get:33 http://archive.ubuntu.com trusty-backports/universe Translation-en [36.8 kB]
==> default: Hit http://archive.ubuntu.com trusty Release
==> default: Get:34 http://archive.ubuntu.com trusty/main Sources [1,064 kB]
==> default: Get:35 http://archive.ubuntu.com trusty/restricted Sources [5,433 B]
==> default: Get:36 http://archive.ubuntu.com trusty/universe Sources [6,399 kB]
==> default: Get:37 http://archive.ubuntu.com trusty/multiverse Sources [174 kB]
==> default: Hit http://archive.ubuntu.com trusty/main amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/restricted amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/universe amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/multiverse amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/main Translation-en
==> default: Hit http://archive.ubuntu.com trusty/multiverse Translation-en
==> default: Hit http://archive.ubuntu.com trusty/restricted Translation-en
==> default: Hit http://archive.ubuntu.com trusty/universe Translation-en
==> default: Ign http://archive.ubuntu.com trusty/main Translation-en_US
==> default: Ign http://archive.ubuntu.com trusty/multiverse Translation-en_US
==> default: Ign http://archive.ubuntu.com trusty/restricted Translation-en_US
==> default: Ign http://archive.ubuntu.com trusty/universe Translation-en_US
==> default: Fetched 11.9 MB in 10s (1,094 kB/s)
==> default: Reading package lists...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   libjemalloc1 redis-tools
==> default: The following NEW packages will be installed:
==> default:   libjemalloc1 redis-server redis-tools
==> default: 0 upgraded, 3 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 410 kB of archives.
==> default: After this operation, 1,272 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/universe libjemalloc1 amd64 3.5.1-2 [76.8 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/universe redis-tools amd64 2:2.8.4-2 [65.7 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty/universe redis-server amd64 2:2.8.4-2 [267 kB]
==> default: Fetched 410 kB in 7s (51.5 kB/s)
==> default: Selecting previously unselected package libjemalloc1.
==> default: (Reading database ... 63024 files and directories currently installed.)
==> default: Preparing to unpack .../libjemalloc1_3.5.1-2_amd64.deb ...
==> default: Unpacking libjemalloc1 (3.5.1-2) ...
==> default: Selecting previously unselected package redis-tools.
==> default: Preparing to unpack .../redis-tools_2%3a2.8.4-2_amd64.deb ...
==> default: Unpacking redis-tools (2:2.8.4-2) ...
==> default: Selecting previously unselected package redis-server.
==> default: Preparing to unpack .../redis-server_2%3a2.8.4-2_amd64.deb ...
==> default: Unpacking redis-server (2:2.8.4-2) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Setting up libjemalloc1 (3.5.1-2) ...
==> default: Setting up redis-tools (2:2.8.4-2) ...
==> default: Setting up redis-server (2:2.8.4-2) ...
==> default: Starting redis-server: 
==> default: redis-server.
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   libopts25
==> default: Suggested packages:
==> default:   ntp-doc
==> default: The following NEW packages will be installed:
==> default:   libopts25 ntp
==> default: 0 upgraded, 2 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 477 kB of archives.
==> default: After this operation, 1,682 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libopts25 amd64 1:5.18-2ubuntu2 [55.3 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main ntp amd64 1:4.2.6.p5+dfsg-3ubuntu2.14.04.10 [421 kB]
==> default: Fetched 477 kB in 4s (109 kB/s)
==> default: Selecting previously unselected package libopts25:amd64.
==> default: (Reading database ... 63053 files and directories currently installed.)
==> default: Preparing to unpack .../libopts25_1%3a5.18-2ubuntu2_amd64.deb ...
==> default: Unpacking libopts25:amd64 (1:5.18-2ubuntu2) ...
==> default: Selecting previously unselected package ntp.
==> default: Preparing to unpack .../ntp_1%3a4.2.6.p5+dfsg-3ubuntu2.14.04.10_amd64.deb ...
==> default: Unpacking ntp (1:4.2.6.p5+dfsg-3ubuntu2.14.04.10) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libopts25:amd64 (1:5.18-2ubuntu2) ...
==> default: Setting up ntp (1:4.2.6.p5+dfsg-3ubuntu2.14.04.10) ...
==> default:  * Starting NTP server ntpd
==> default:    ...done.
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default:  * Stopping NTP server ntpd
==> default:    ...done.
==> default:  * Starting NTP server ntpd
==> default:    ...done.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: Suggested packages:
==> default:   zip
==> default: The following NEW packages will be installed:
==> default:   unzip
==> default: 0 upgraded, 1 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 157 kB of archives.
==> default: After this operation, 395 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main unzip amd64 6.0-9ubuntu1.5 [157 kB]
==> default: Fetched 157 kB in 0s (226 kB/s)
==> default: Selecting previously unselected package unzip.
==> default: (Reading database ... 63096 files and directories currently installed.)
==> default: Preparing to unpack .../unzip_6.0-9ubuntu1.5_amd64.deb ...
==> default: Unpacking unzip (6.0-9ubuntu1.5) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for mime-support (3.54ubuntu1.1) ...
==> default: Setting up unzip (6.0-9ubuntu1.5) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: curl is already the newest version.
==> default: vim is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   git-man liberror-perl
==> default: Suggested packages:
==> default:   git-daemon-run git-daemon-sysvinit git-doc git-el git-email git-gui gitk
==> default:   gitweb git-arch git-bzr git-cvs git-mediawiki git-svn
==> default: The following NEW packages will be installed:
==> default:   git git-man liberror-perl
==> default: 0 upgraded, 3 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 3,306 kB of archives.
==> default: After this operation, 21.9 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main liberror-perl all 0.17-1.1 [21.1 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main git-man all 1:1.9.1-1ubuntu0.3 [699 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main git amd64 1:1.9.1-1ubuntu0.3 [2,586 kB]
==> default: Fetched 3,306 kB in 2s (1,402 kB/s)
==> default: Selecting previously unselected package liberror-perl.
==> default: (Reading database ... 63114 files and directories currently installed.)
==> default: Preparing to unpack .../liberror-perl_0.17-1.1_all.deb ...
==> default: Unpacking liberror-perl (0.17-1.1) ...
==> default: Selecting previously unselected package git-man.
==> default: Preparing to unpack .../git-man_1%3a1.9.1-1ubuntu0.3_all.deb ...
==> default: Unpacking git-man (1:1.9.1-1ubuntu0.3) ...
==> default: Selecting previously unselected package git.
==> default: Preparing to unpack .../git_1%3a1.9.1-1ubuntu0.3_amd64.deb ...
==> default: Unpacking git (1:1.9.1-1ubuntu0.3) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up liberror-perl (0.17-1.1) ...
==> default: Setting up git-man (1:1.9.1-1ubuntu0.3) ...
==> default: Setting up git (1:1.9.1-1ubuntu0.3) ...
==> default: Install PHP things
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   php5-apcu php5-common php5-json
==> default: Suggested packages:
==> default:   php5-gd php5-user-cache
==> default: The following NEW packages will be installed:
==> default:   php-apc php5-apcu php5-common php5-json
==> default: 0 upgraded, 4 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 558 kB of archives.
==> default: After this operation, 1,662 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main php5-json amd64 1.3.2-2build1 [34.4 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-common amd64 5.5.9+dfsg-1ubuntu4.20 [447 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty/universe php5-apcu amd64 4.0.2-2build1 [73.2 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty/universe php-apc all 4.0.2-2build1 [2,762 B]
==> default: Fetched 558 kB in 2s (252 kB/s)
==> default: Selecting previously unselected package php5-json.
==> default: (Reading database ... 63862 files and directories currently installed.)
==> default: Preparing to unpack .../php5-json_1.3.2-2build1_amd64.deb ...
==> default: Unpacking php5-json (1.3.2-2build1) ...
==> default: Selecting previously unselected package php5-common.
==> default: Preparing to unpack .../php5-common_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-common (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php5-apcu.
==> default: Preparing to unpack .../php5-apcu_4.0.2-2build1_amd64.deb ...
==> default: Unpacking php5-apcu (4.0.2-2build1) ...
==> default: Selecting previously unselected package php-apc.
==> default: Preparing to unpack .../php-apc_4.0.2-2build1_all.deb ...
==> default: Unpacking php-apc (4.0.2-2build1) ...
==> default: Setting up php5-json (1.3.2-2build1) ...
==> default: Setting up php5-common (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up php5-apcu (4.0.2-2build1) ...
==> default: Setting up php-apc (4.0.2-2build1) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   apache2 apache2-bin apache2-data libapache2-mod-php5 libapr1 libaprutil1
==> default:   libaprutil1-dbd-sqlite3 libaprutil1-ldap pear-channels php-codecoverage
==> default:   php-file-iterator php-invoker php-pear php-symfony2-yaml php-text-template
==> default:   php-timer php-token-stream php5 php5-cli php5-readline php5-xdebug
==> default:   phpunit-mock-object phpunit-story ssl-cert
==> default: Suggested packages:
==> default:   apache2-doc apache2-suexec-pristine apache2-suexec-custom apache2-utils
==> default:   php5-dev phpunit-selenium openssl-blacklist
==> default: The following NEW packages will be installed:
==> default:   apache2 apache2-bin apache2-data libapache2-mod-php5 libapr1 libaprutil1
==> default:   libaprutil1-dbd-sqlite3 libaprutil1-ldap pear-channels php-codecoverage
==> default:   php-file-iterator php-invoker php-pear php-symfony2-yaml php-text-template
==> default:   php-timer php-token-stream php5 php5-cli php5-readline php5-xdebug phpunit
==> default:   phpunit-mock-object phpunit-story ssl-cert
==> default: 0 upgraded, 25 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 6,468 kB of archives.
==> default: After this operation, 30.4 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libapr1 amd64 1.5.0-1 [85.1 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1 amd64 1.5.3-1 [76.4 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-cli amd64 5.5.9+dfsg-1ubuntu4.20 [2,164 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-readline amd64 5.5.9+dfsg-1ubuntu4.20 [12.1 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1-dbd-sqlite3 amd64 1.5.3-1 [10.5 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1-ldap amd64 1.5.3-1 [8,634 B]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2-bin amd64 2.4.7-1ubuntu4.13 [839 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2-data all 2.4.7-1ubuntu4.13 [160 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2 amd64 2.4.7-1ubuntu4.13 [87.4 kB]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libapache2-mod-php5 amd64 5.5.9+dfsg-1ubuntu4.20 [2,210 kB]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php-pear all 5.5.9+dfsg-1ubuntu4.20 [267 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty/universe pear-channels all 0~20131124-1 [5,846 B]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5 all 5.5.9+dfsg-1ubuntu4.20 [1,306 B]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty/universe php-file-iterator all 1.3.1-2 [7,702 B]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty/universe php-token-stream all 1.1.3-2 [12.4 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/universe php-text-template all 1.1.1-2 [6,070 B]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty/universe php-codecoverage all 1.2.13+dfsg1-1 [76.5 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/universe php-timer all 1.0.5-1 [6,016 B]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/universe php-invoker all 1.1.0-1 [6,134 B]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty/universe php-symfony2-yaml all 2.4.1-1 [16.6 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/universe php5-xdebug amd64 2.2.3-2build1 [253 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit-mock-object all 1.2.3-1 [23.6 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit all 3.7.28-1 [104 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit-story all 1.0.0-3 [11.4 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty/main ssl-cert all 1.0.33 [16.6 kB]
==> default: Fetched 6,468 kB in 5s (1,255 kB/s)
==> default: Selecting previously unselected package libapr1:amd64.
==> default: (Reading database ... 63943 files and directories currently installed.)
==> default: Preparing to unpack .../libapr1_1.5.0-1_amd64.deb ...
==> default: Unpacking libapr1:amd64 (1.5.0-1) ...
==> default: Selecting previously unselected package libaprutil1:amd64.
==> default: Preparing to unpack .../libaprutil1_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package php5-cli.
==> default: Preparing to unpack .../php5-cli_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-cli (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php5-readline.
==> default: Preparing to unpack .../php5-readline_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-readline (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package libaprutil1-dbd-sqlite3:amd64.
==> default: Preparing to unpack .../libaprutil1-dbd-sqlite3_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1-dbd-sqlite3:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package libaprutil1-ldap:amd64.
==> default: Preparing to unpack .../libaprutil1-ldap_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1-ldap:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package apache2-bin.
==> default: Preparing to unpack .../apache2-bin_2.4.7-1ubuntu4.13_amd64.deb ...
==> default: Unpacking apache2-bin (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package apache2-data.
==> default: Preparing to unpack .../apache2-data_2.4.7-1ubuntu4.13_all.deb ...
==> default: Unpacking apache2-data (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package apache2.
==> default: Preparing to unpack .../apache2_2.4.7-1ubuntu4.13_amd64.deb ...
==> default: Unpacking apache2 (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package libapache2-mod-php5.
==> default: Preparing to unpack .../libapache2-mod-php5_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking libapache2-mod-php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php-pear.
==> default: Preparing to unpack .../php-pear_5.5.9+dfsg-1ubuntu4.20_all.deb ...
==> default: Unpacking php-pear (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package pear-channels.
==> default: Preparing to unpack .../pear-channels_0~20131124-1_all.deb ...
==> default: Unpacking pear-channels (0~20131124-1) ...
==> default: Selecting previously unselected package php5.
==> default: Preparing to unpack .../php5_5.5.9+dfsg-1ubuntu4.20_all.deb ...
==> default: Unpacking php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php-file-iterator.
==> default: Preparing to unpack .../php-file-iterator_1.3.1-2_all.deb ...
==> default: Unpacking php-file-iterator (1.3.1-2) ...
==> default: Selecting previously unselected package php-token-stream.
==> default: Preparing to unpack .../php-token-stream_1.1.3-2_all.deb ...
==> default: Unpacking php-token-stream (1.1.3-2) ...
==> default: Selecting previously unselected package php-text-template.
==> default: Preparing to unpack .../php-text-template_1.1.1-2_all.deb ...
==> default: Unpacking php-text-template (1.1.1-2) ...
==> default: Selecting previously unselected package php-codecoverage.
==> default: Preparing to unpack .../php-codecoverage_1.2.13+dfsg1-1_all.deb ...
==> default: Unpacking php-codecoverage (1.2.13+dfsg1-1) ...
==> default: Selecting previously unselected package php-timer.
==> default: Preparing to unpack .../php-timer_1.0.5-1_all.deb ...
==> default: Unpacking php-timer (1.0.5-1) ...
==> default: Selecting previously unselected package php-invoker.
==> default: Preparing to unpack .../php-invoker_1.1.0-1_all.deb ...
==> default: Unpacking php-invoker (1.1.0-1) ...
==> default: Selecting previously unselected package php-symfony2-yaml.
==> default: Preparing to unpack .../php-symfony2-yaml_2.4.1-1_all.deb ...
==> default: Unpacking php-symfony2-yaml (2.4.1-1) ...
==> default: Selecting previously unselected package php5-xdebug.
==> default: Preparing to unpack .../php5-xdebug_2.2.3-2build1_amd64.deb ...
==> default: Unpacking php5-xdebug (2.2.3-2build1) ...
==> default: Selecting previously unselected package phpunit-mock-object.
==> default: Preparing to unpack .../phpunit-mock-object_1.2.3-1_all.deb ...
==> default: Unpacking phpunit-mock-object (1.2.3-1) ...
==> default: Selecting previously unselected package phpunit.
==> default: Preparing to unpack .../phpunit_3.7.28-1_all.deb ...
==> default: Unpacking phpunit (3.7.28-1) ...
==> default: Selecting previously unselected package phpunit-story.
==> default: Preparing to unpack .../phpunit-story_1.0.0-3_all.deb ...
==> default: Unpacking phpunit-story (1.0.0-3) ...
==> default: Selecting previously unselected package ssl-cert.
==> default: Preparing to unpack .../ssl-cert_1.0.33_all.deb ...
==> default: Unpacking ssl-cert (1.0.33) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for ufw (0.34~rc-0ubuntu2) ...
==> default: Setting up libapr1:amd64 (1.5.0-1) ...
==> default: Setting up libaprutil1:amd64 (1.5.3-1) ...
==> default: Setting up php5-cli (5.5.9+dfsg-1ubuntu4.20) ...
==> default: update-alternatives: 
==> default: using /usr/bin/php5 to provide /usr/bin/php (php) in auto mode
==> default: Setting up php5-readline (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up libaprutil1-dbd-sqlite3:amd64 (1.5.3-1) ...
==> default: Setting up libaprutil1-ldap:amd64 (1.5.3-1) ...
==> default: Setting up apache2-bin (2.4.7-1ubuntu4.13) ...
==> default: Setting up apache2-data (2.4.7-1ubuntu4.13) ...
==> default: Setting up apache2 (2.4.7-1ubuntu4.13) ...
==> default: Enabling module mpm_event.
==> default: Enabling module authz_core.
==> default: Enabling module authz_host.
==> default: Enabling module authn_core.
==> default: Enabling module auth_basic.
==> default: Enabling module access_compat.
==> default: Enabling module authn_file.
==> default: Enabling module authz_user.
==> default: Enabling module alias.
==> default: Enabling module dir.
==> default: Enabling module autoindex.
==> default: Enabling module env.
==> default: Enabling module mime.
==> default: Enabling module negotiation.
==> default: Enabling module setenvif.
==> default: Enabling module filter.
==> default: Enabling module deflate.
==> default: Enabling module status.
==> default: Enabling conf charset.
==> default: Enabling conf localized-error-pages.
==> default: Enabling conf other-vhosts-access-log.
==> default: Enabling conf security.
==> default: Enabling conf serve-cgi-bin.
==> default: Enabling site 000-default.
==> default:  * Starting web server apache2
==> default:  * 
==> default: Setting up php-pear (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up pear-channels (0~20131124-1) ...
==> default: Setting up php-timer (1.0.5-1) ...
==> default: Setting up php-invoker (1.1.0-1) ...
==> default: Setting up php-symfony2-yaml (2.4.1-1) ...
==> default: Setting up php5-xdebug (2.2.3-2build1) ...
==> default: Setting up ssl-cert (1.0.33) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for ufw (0.34~rc-0ubuntu2) ...
==> default: Setting up libapache2-mod-php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Module mpm_event disabled.
==> default: Enabling module mpm_prefork.
==> default:  * Restarting web server apache2
==> default:    ...done.
==> default:  * Restarting web server apache2
==> default:    ...done.
==> default: Setting up php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up php-file-iterator (1.3.1-2) ...
==> default: Setting up php-token-stream (1.1.3-2) ...
==> default: Setting up php-text-template (1.1.1-2) ...
==> default: Setting up php-codecoverage (1.2.13+dfsg1-1) ...
==> default: Setting up phpunit-mock-object (1.2.3-1) ...
==> default: Setting up phpunit (3.7.28-1) ...
==> default: Setting up phpunit-story (1.0.0-3) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following NEW packages will be installed:
==> default:   apache2-dev aspell aspell-en autoconf automake autotools-dev bison
==> default:   build-essential chrpath comerr-dev debhelper dh-apparmor dictionaries-common
==> default:   dpkg-dev flex freetds-common freetds-dev g++ g++-4.8 gettext icu-devtools
==> default:   intltool-debian krb5-multidev language-pack-de language-pack-de-base libaio1
==> default:   libapr1-dev libaprutil1-dev libaspell-dev libaspell15 libbison-dev
==> default:   libbsd-dev libbz2-dev libcroco3 libct4 libcurl4-openssl-dev libdb-dev
==> default:   libdb5.3-dev libdbd-mysql-perl libdbi-perl libdpkg-perl libedit-dev libelfg0
==> default:   libenchant-dev libenchant1c2a libevent-core-2.0-5 libevent-dev
==> default:   libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5
==> default:   libexpat1-dev libfl-dev libfontconfig1-dev libfreetype6-dev libgcrypt11-dev
==> default:   libgd-dev libglib2.0-bin libglib2.0-dev libgmp-dev libgmp3-dev libgmpxx4ldbl
==> default:   libgnutls-dev libgnutlsxx27 libgpg-error-dev libgssrpc4 libhunspell-1.3-0
==> default:   libice-dev libicu-dev libidn11-dev libjbig-dev libjpeg-dev
==> default:   libjpeg-turbo8-dev libjpeg8-dev libkadm5clnt-mit9 libkadm5srv-mit9 libkdb5-7
==> default:   libkrb5-dev libldap2-dev libltdl-dev liblzma-dev libmagic-dev libmhash-dev
==> default:   libmhash2 libmysqlclient-dev libmysqlclient18 libodbc1 libp11-kit-dev
==> default:   libpam0g-dev libpcre3-dev libpcrecpp0 libperl5.18 libpng12-dev libpq-dev
==> default:   libpq5 libpspell-dev libpthread-stubs0-dev librecode-dev librecode0
==> default:   librtmp-dev libsasl2-dev libsctp-dev libsctp1 libsensors4 libsensors4-dev
==> default:   libsm-dev libsnmp-base libsnmp-dev libsnmp30 libsqlite3-dev libssl-dev
==> default:   libstdc++-4.8-dev libsybdb5 libsystemd-daemon-dev libtasn1-6-dev
==> default:   libterm-readkey-perl libtidy-0.99-0 libtidy-dev libtiff5-dev libtiffxx5
==> default:   libtinfo-dev libtool libunistring0 libvpx-dev libwrap0-dev libx11-dev
==> default:   libxau-dev libxcb1-dev libxdmcp-dev libxml2-dev libxmltok1 libxmltok1-dev
==> default:   libxpm-dev libxslt1-dev libxslt1.1 libxt-dev m4 mysql-client-5.5
==> default:   mysql-client-core-5.5 mysql-common mysql-server mysql-server-5.5
==> default:   mysql-server-core-5.5 odbcinst odbcinst1debian2 pkg-config po-debconf re2c
==> default:   systemtap-sdt-dev unixodbc unixodbc-dev uuid-dev x11proto-core-dev
==> default:   x11proto-input-dev x11proto-kb-dev xorg-sgml-doctools xtrans-dev zlib1g-dev
==> default: 0 upgraded, 157 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 68.8 MB of archives.
==> default: After this operation, 329 MB of additional disk space will be used.
==> default: Do you want to continue?
==> default:  [Y/n] 
==> default: Abort.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: curl is already the newest version.
==> default: libxml2 is already the newest version.
==> default: php-pear is already the newest version.
==> default: php-pear set to manually installed.
==> default: php5 is already the newest version.
==> default: php5 set to manually installed.
==> default: php5-cli is already the newest version.
==> default: php5-cli set to manually installed.
==> default: The following extra packages will be installed:
==> default:   autotools-dev debhelper dh-apparmor dpkg-dev g++ g++-4.8 gettext
==> default:   intltool-debian libalgorithm-diff-perl libalgorithm-diff-xs-perl
==> default:   libalgorithm-merge-perl libasprintf-dev libbison-dev libcroco3 libdpkg-perl
==> default:   libfile-fcntllock-perl libgettextpo-dev libgettextpo0 libltdl-dev
==> default:   libmail-sendmail-perl libreadline6-dev libssl-dev libssl-doc
==> default:   libstdc++-4.8-dev libsys-hostname-long-perl libtinfo-dev libtool
==> default:   libunistring0 libxslt1.1 m4 pkg-php-tools po-debconf shtool zlib1g-dev
==> default: Suggested packages:
==> default:   autoconf2.13 autoconf-archive gnu-standards autoconf-doc bison-doc dh-make
==> default:   apparmor-easyprof debian-keyring g++-multilib g++-4.8-multilib gcc-4.8-doc
==> default:   libstdc++6-4.8-dbg gettext-doc libtool-doc libstdc++-4.8-doc automaken
==> default:   gfortran fortran95-compiler gcj-jdk pkg-config libmail-box-perl
==> default: The following NEW packages will be installed:
==> default:   autoconf automake autotools-dev bison build-essential debhelper dh-apparmor
==> default:   dpkg-dev g++ g++-4.8 gettext intltool-debian libalgorithm-diff-perl
==> default:   libalgorithm-diff-xs-perl libalgorithm-merge-perl libasprintf-dev
==> default:   libbison-dev libbz2-dev libcroco3 libdpkg-perl libfile-fcntllock-perl
==> default:   libgettextpo-dev libgettextpo0 libltdl-dev libmail-sendmail-perl
==> default:   libreadline-dev libreadline6-dev libssl-dev libssl-doc libstdc++-4.8-dev
==> default:   libsys-hostname-long-perl libtinfo-dev libtool libunistring0 libxml2-dev
==> default:   libxslt1-dev libxslt1.1 m4 php5-dev pkg-php-tools po-debconf re2c shtool
==> default:   zlib1g-dev
==> default: 0 upgraded, 44 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 29.0 MB of archives.
==> default: After this operation, 80.4 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libcroco3 amd64 0.6.8-2ubuntu1 [82.4 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libunistring0 amd64 0.9.3-5ubuntu3 [271 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgettextpo0 amd64 0.18.3.1-1ubuntu3 [108 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty/main libxslt1.1 amd64 1.1.28-2build1 [145 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main m4 amd64 1.4.17-2ubuntu1 [195 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main autoconf all 2.69-6 [322 kB]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty/main autotools-dev all 20130810.1 [44.3 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty/main automake all 1:1.14.1-2ubuntu1 [510 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty/main libbison-dev amd64 2:3.0.2.dfsg-2 [338 kB]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty/main bison amd64 2:3.0.2.dfsg-2 [257 kB]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libstdc++-4.8-dev amd64 4.8.4-2ubuntu1~14.04.3 [1,053 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty-updates/main g++-4.8 amd64 4.8.4-2ubuntu1~14.04.3 [18.1 MB]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty/main g++ amd64 4:4.8.2-1ubuntu6 [1,490 B]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libdpkg-perl all 1.17.5ubuntu5.7 [179 kB]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty-updates/main dpkg-dev all 1.17.5ubuntu5.7 [726 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/main build-essential amd64 11.6ubuntu6 [4,838 B]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty-updates/main gettext amd64 0.18.3.1-1ubuntu3 [829 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/main intltool-debian all 0.35.0+20060710.1 [31.6 kB]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/main po-debconf all 1.0.16+nmu2ubuntu1 [210 kB]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty-updates/main dh-apparmor all 2.8.95~2430-0ubuntu5.3 [12.2 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/main debhelper all 9.20131227ubuntu1 [604 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-perl all 1.19.02-3 [50.0 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-xs-perl amd64 0.04-2build4 [12.6 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-merge-perl all 0.08-2 [12.7 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libasprintf-dev amd64 0.18.3.1-1ubuntu3 [4,438 B]
==> default: Get:26 http://archive.ubuntu.com/ubuntu/ trusty/main libbz2-dev amd64 1.0.6-5 [33.2 kB]
==> default: Get:27 http://archive.ubuntu.com/ubuntu/ trusty/main libfile-fcntllock-perl amd64 0.14-2build1 [15.9 kB]
==> default: Get:28 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgettextpo-dev amd64 0.18.3.1-1ubuntu3 [122 kB]
==> default: Get:29 http://archive.ubuntu.com/ubuntu/ trusty/main libltdl-dev amd64 2.4.2-1.7ubuntu1 [157 kB]
==> default: Get:30 http://archive.ubuntu.com/ubuntu/ trusty/main libsys-hostname-long-perl all 1.4-3 [11.3 kB]
==> default: Get:31 http://archive.ubuntu.com/ubuntu/ trusty/main libmail-sendmail-perl all 0.79.16-1 [26.5 kB]
==> default: Get:32 http://archive.ubuntu.com/ubuntu/ trusty/main libtinfo-dev amd64 5.9+20140118-1ubuntu1 [76.3 kB]
==> default: Get:33 http://archive.ubuntu.com/ubuntu/ trusty/main libreadline6-dev amd64 6.3-4ubuntu2 [213 kB]
==> default: Get:34 http://archive.ubuntu.com/ubuntu/ trusty/main libreadline-dev amd64 6.3-4ubuntu2 [988 B]
==> default: Get:35 http://archive.ubuntu.com/ubuntu/ trusty/main zlib1g-dev amd64 1:1.2.8.dfsg-1ubuntu1 [183 kB]
==> default: Get:36 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-dev amd64 1.0.1f-1ubuntu2.21 [1,074 kB]
==> default: Get:37 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-doc all 1.0.1f-1ubuntu2.21 [971 kB]
==> default: Get:38 http://archive.ubuntu.com/ubuntu/ trusty/main libtool amd64 2.4.2-1.7ubuntu1 [188 kB]
==> default: Get:39 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libxml2-dev amd64 2.9.1+dfsg1-3ubuntu4.8 [631 kB]
==> default: Get:40 http://archive.ubuntu.com/ubuntu/ trusty/main libxslt1-dev amd64 1.1.28-2build1 [407 kB]
==> default: Get:41 http://archive.ubuntu.com/ubuntu/ trusty/main shtool all 2.0.8-6 [149 kB]
==> default: Get:42 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-dev amd64 5.5.9+dfsg-1ubuntu4.20 [356 kB]
==> default: Get:43 http://archive.ubuntu.com/ubuntu/ trusty/main re2c amd64 0.13.5-1build2 [208 kB]
==> default: Get:44 http://archive.ubuntu.com/ubuntu/ trusty/main pkg-php-tools all 1.11 [21.6 kB]
==> default: Fetched 29.0 MB in 3min 13s (150 kB/s)
==> default: Selecting previously unselected package libcroco3:amd64.
==> default: (Reading database ... 65226 files and directories currently installed.)
==> default: Preparing to unpack .../libcroco3_0.6.8-2ubuntu1_amd64.deb ...
==> default: Unpacking libcroco3:amd64 (0.6.8-2ubuntu1) ...
==> default: Selecting previously unselected package libunistring0:amd64.
==> default: Preparing to unpack .../libunistring0_0.9.3-5ubuntu3_amd64.deb ...
==> default: Unpacking libunistring0:amd64 (0.9.3-5ubuntu3) ...
==> default: Selecting previously unselected package libgettextpo0:amd64.
==> default: Preparing to unpack .../libgettextpo0_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libgettextpo0:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libxslt1.1:amd64.
==> default: Preparing to unpack .../libxslt1.1_1.1.28-2build1_amd64.deb ...
==> default: Unpacking libxslt1.1:amd64 (1.1.28-2build1) ...
==> default: Selecting previously unselected package m4.
==> default: Preparing to unpack .../m4_1.4.17-2ubuntu1_amd64.deb ...
==> default: Unpacking m4 (1.4.17-2ubuntu1) ...
==> default: Selecting previously unselected package autoconf.
==> default: Preparing to unpack .../autoconf_2.69-6_all.deb ...
==> default: Unpacking autoconf (2.69-6) ...
==> default: Selecting previously unselected package autotools-dev.
==> default: Preparing to unpack .../autotools-dev_20130810.1_all.deb ...
==> default: Unpacking autotools-dev (20130810.1) ...
==> default: Selecting previously unselected package automake.
==> default: Preparing to unpack .../automake_1%3a1.14.1-2ubuntu1_all.deb ...
==> default: Unpacking automake (1:1.14.1-2ubuntu1) ...
==> default: Selecting previously unselected package libbison-dev:amd64.
==> default: Preparing to unpack .../libbison-dev_2%3a3.0.2.dfsg-2_amd64.deb ...
==> default: Unpacking libbison-dev:amd64 (2:3.0.2.dfsg-2) ...
==> default: Selecting previously unselected package bison.
==> default: Preparing to unpack .../bison_2%3a3.0.2.dfsg-2_amd64.deb ...
==> default: Unpacking bison (2:3.0.2.dfsg-2) ...
==> default: Selecting previously unselected package libstdc++-4.8-dev:amd64.
==> default: Preparing to unpack .../libstdc++-4.8-dev_4.8.4-2ubuntu1~14.04.3_amd64.deb ...
==> default: Unpacking libstdc++-4.8-dev:amd64 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Selecting previously unselected package g++-4.8.
==> default: Preparing to unpack .../g++-4.8_4.8.4-2ubuntu1~14.04.3_amd64.deb ...
==> default: Unpacking g++-4.8 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Selecting previously unselected package g++.
==> default: Preparing to unpack .../g++_4%3a4.8.2-1ubuntu6_amd64.deb ...
==> default: Unpacking g++ (4:4.8.2-1ubuntu6) ...
==> default: Selecting previously unselected package libdpkg-perl.
==> default: Preparing to unpack .../libdpkg-perl_1.17.5ubuntu5.7_all.deb ...
==> default: Unpacking libdpkg-perl (1.17.5ubuntu5.7) ...
==> default: Selecting previously unselected package dpkg-dev.
==> default: Preparing to unpack .../dpkg-dev_1.17.5ubuntu5.7_all.deb ...
==> default: Unpacking dpkg-dev (1.17.5ubuntu5.7) ...
==> default: Selecting previously unselected package build-essential.
==> default: Preparing to unpack .../build-essential_11.6ubuntu6_amd64.deb ...
==> default: Unpacking build-essential (11.6ubuntu6) ...
==> default: Selecting previously unselected package gettext.
==> default: Preparing to unpack .../gettext_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking gettext (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package intltool-debian.
==> default: Preparing to unpack .../intltool-debian_0.35.0+20060710.1_all.deb ...
==> default: Unpacking intltool-debian (0.35.0+20060710.1) ...
==> default: Selecting previously unselected package po-debconf.
==> default: Preparing to unpack .../po-debconf_1.0.16+nmu2ubuntu1_all.deb ...
==> default: Unpacking po-debconf (1.0.16+nmu2ubuntu1) ...
==> default: Selecting previously unselected package dh-apparmor.
==> default: Preparing to unpack .../dh-apparmor_2.8.95~2430-0ubuntu5.3_all.deb ...
==> default: Unpacking dh-apparmor (2.8.95~2430-0ubuntu5.3) ...
==> default: Selecting previously unselected package debhelper.
==> default: Preparing to unpack .../debhelper_9.20131227ubuntu1_all.deb ...
==> default: Unpacking debhelper (9.20131227ubuntu1) ...
==> default: Selecting previously unselected package libalgorithm-diff-perl.
==> default: Preparing to unpack .../libalgorithm-diff-perl_1.19.02-3_all.deb ...
==> default: Unpacking libalgorithm-diff-perl (1.19.02-3) ...
==> default: Selecting previously unselected package libalgorithm-diff-xs-perl.
==> default: Preparing to unpack .../libalgorithm-diff-xs-perl_0.04-2build4_amd64.deb ...
==> default: Unpacking libalgorithm-diff-xs-perl (0.04-2build4) ...
==> default: Selecting previously unselected package libalgorithm-merge-perl.
==> default: Preparing to unpack .../libalgorithm-merge-perl_0.08-2_all.deb ...
==> default: Unpacking libalgorithm-merge-perl (0.08-2) ...
==> default: Selecting previously unselected package libasprintf-dev:amd64.
==> default: Preparing to unpack .../libasprintf-dev_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libasprintf-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libbz2-dev:amd64.
==> default: Preparing to unpack .../libbz2-dev_1.0.6-5_amd64.deb ...
==> default: Unpacking libbz2-dev:amd64 (1.0.6-5) ...
==> default: Selecting previously unselected package libfile-fcntllock-perl.
==> default: Preparing to unpack .../libfile-fcntllock-perl_0.14-2build1_amd64.deb ...
==> default: Unpacking libfile-fcntllock-perl (0.14-2build1) ...
==> default: Selecting previously unselected package libgettextpo-dev:amd64.
==> default: Preparing to unpack .../libgettextpo-dev_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libgettextpo-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libltdl-dev:amd64.
==> default: Preparing to unpack .../libltdl-dev_2.4.2-1.7ubuntu1_amd64.deb ...
==> default: Unpacking libltdl-dev:amd64 (2.4.2-1.7ubuntu1) ...
==> default: Selecting previously unselected package libsys-hostname-long-perl.
==> default: Preparing to unpack .../libsys-hostname-long-perl_1.4-3_all.deb ...
==> default: Unpacking libsys-hostname-long-perl (1.4-3) ...
==> default: Selecting previously unselected package libmail-sendmail-perl.
==> default: Preparing to unpack .../libmail-sendmail-perl_0.79.16-1_all.deb ...
==> default: Unpacking libmail-sendmail-perl (0.79.16-1) ...
==> default: Selecting previously unselected package libtinfo-dev:amd64.
==> default: Preparing to unpack .../libtinfo-dev_5.9+20140118-1ubuntu1_amd64.deb ...
==> default: Unpacking libtinfo-dev:amd64 (5.9+20140118-1ubuntu1) ...
==> default: Selecting previously unselected package libreadline6-dev:amd64.
==> default: Preparing to unpack .../libreadline6-dev_6.3-4ubuntu2_amd64.deb ...
==> default: Unpacking libreadline6-dev:amd64 (6.3-4ubuntu2) ...
==> default: Selecting previously unselected package libreadline-dev:amd64.
==> default: Preparing to unpack .../libreadline-dev_6.3-4ubuntu2_amd64.deb ...
==> default: Unpacking libreadline-dev:amd64 (6.3-4ubuntu2) ...
==> default: Selecting previously unselected package zlib1g-dev:amd64.
==> default: Preparing to unpack .../zlib1g-dev_1%3a1.2.8.dfsg-1ubuntu1_amd64.deb ...
==> default: Unpacking zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...
==> default: Selecting previously unselected package libssl-dev:amd64.
==> default: Preparing to unpack .../libssl-dev_1.0.1f-1ubuntu2.21_amd64.deb ...
==> default: Unpacking libssl-dev:amd64 (1.0.1f-1ubuntu2.21) ...
==> default: Selecting previously unselected package libssl-doc.
==> default: Preparing to unpack .../libssl-doc_1.0.1f-1ubuntu2.21_all.deb ...
==> default: Unpacking libssl-doc (1.0.1f-1ubuntu2.21) ...
==> default: Selecting previously unselected package libtool.
==> default: Preparing to unpack .../libtool_2.4.2-1.7ubuntu1_amd64.deb ...
==> default: Unpacking libtool (2.4.2-1.7ubuntu1) ...
==> default: Selecting previously unselected package libxml2-dev:amd64.
==> default: Preparing to unpack .../libxml2-dev_2.9.1+dfsg1-3ubuntu4.8_amd64.deb ...
==> default: Unpacking libxml2-dev:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...
==> default: Selecting previously unselected package libxslt1-dev:amd64.
==> default: Preparing to unpack .../libxslt1-dev_1.1.28-2build1_amd64.deb ...
==> default: Unpacking libxslt1-dev:amd64 (1.1.28-2build1) ...
==> default: Selecting previously unselected package shtool.
==> default: Preparing to unpack .../shtool_2.0.8-6_all.deb ...
==> default: Unpacking shtool (2.0.8-6) ...
==> default: Selecting previously unselected package php5-dev.
==> default: Preparing to unpack .../php5-dev_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-dev (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package re2c.
==> default: Preparing to unpack .../re2c_0.13.5-1build2_amd64.deb ...
==> default: Unpacking re2c (0.13.5-1build2) ...
==> default: Selecting previously unselected package pkg-php-tools.
==> default: Preparing to unpack .../pkg-php-tools_1.11_all.deb ...
==> default: Unpacking pkg-php-tools (1.11) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for install-info (5.2.0.dfsg.1-2) ...
==> default: Setting up libcroco3:amd64 (0.6.8-2ubuntu1) ...
==> default: Setting up libunistring0:amd64 (0.9.3-5ubuntu3) ...
==> default: Setting up libgettextpo0:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libxslt1.1:amd64 (1.1.28-2build1) ...
==> default: Setting up m4 (1.4.17-2ubuntu1) ...
==> default: Setting up autoconf (2.69-6) ...
==> default: Setting up autotools-dev (20130810.1) ...
==> default: Setting up automake (1:1.14.1-2ubuntu1) ...
==> default: update-alternatives: 
==> default: using /usr/bin/automake-1.14 to provide /usr/bin/automake (automake) in auto mode
==> default: Setting up libbison-dev:amd64 (2:3.0.2.dfsg-2) ...
==> default: Setting up bison (2:3.0.2.dfsg-2) ...
==> default: update-alternatives: 
==> default: using /usr/bin/bison.yacc to provide /usr/bin/yacc (yacc) in auto mode
==> default: Setting up libstdc++-4.8-dev:amd64 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Setting up g++-4.8 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Setting up g++ (4:4.8.2-1ubuntu6) ...
==> default: update-alternatives: 
==> default: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
==> default: Setting up libdpkg-perl (1.17.5ubuntu5.7) ...
==> default: Setting up dpkg-dev (1.17.5ubuntu5.7) ...
==> default: Setting up build-essential (11.6ubuntu6) ...
==> default: Setting up gettext (0.18.3.1-1ubuntu3) ...
==> default: Setting up intltool-debian (0.35.0+20060710.1) ...
==> default: Setting up po-debconf (1.0.16+nmu2ubuntu1) ...
==> default: Setting up dh-apparmor (2.8.95~2430-0ubuntu5.3) ...
==> default: Setting up debhelper (9.20131227ubuntu1) ...
==> default: Setting up libalgorithm-diff-perl (1.19.02-3) ...
==> default: Setting up libalgorithm-diff-xs-perl (0.04-2build4) ...
==> default: Setting up libalgorithm-merge-perl (0.08-2) ...
==> default: Setting up libasprintf-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libbz2-dev:amd64 (1.0.6-5) ...
==> default: Setting up libfile-fcntllock-perl (0.14-2build1) ...
==> default: Setting up libgettextpo-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libltdl-dev:amd64 (2.4.2-1.7ubuntu1) ...
==> default: Setting up libsys-hostname-long-perl (1.4-3) ...
==> default: Setting up libmail-sendmail-perl (0.79.16-1) ...
==> default: Setting up libtinfo-dev:amd64 (5.9+20140118-1ubuntu1) ...
==> default: Setting up libreadline6-dev:amd64 (6.3-4ubuntu2) ...
==> default: Setting up libreadline-dev:amd64 (6.3-4ubuntu2) ...
==> default: Setting up zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...
==> default: Setting up libssl-dev:amd64 (1.0.1f-1ubuntu2.21) ...
==> default: Setting up libssl-doc (1.0.1f-1ubuntu2.21) ...
==> default: Setting up libtool (2.4.2-1.7ubuntu1) ...
==> default: Setting up libxml2-dev:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...
==> default: Setting up libxslt1-dev:amd64 (1.1.28-2build1) ...
==> default: Setting up shtool (2.0.8-6) ...
==> default: Setting up php5-dev (5.5.9+dfsg-1ubuntu4.20) ...
==> default: update-alternatives: 
==> default: using /usr/bin/php-config5 to provide /usr/bin/php-config (php-config) in auto mode
==> default: update-alternatives: 
==> default: using /usr/bin/phpize5 to provide /usr/bin/phpize (phpize) in auto mode
==> default: Setting up re2c (0.13.5-1build2) ...
==> default: Setting up pkg-php-tools (1.11) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libjpeg8 is already the newest version.
==> default: libjpeg8 set to manually installed.
==> default: libltdl-dev is already the newest version.
==> default: libltdl-dev set to manually installed.
==> default: libltdl7 is already the newest version.
==> default: libltdl7 set to manually installed.
==> default: libxpm4 is already the newest version.
==> default: libxpm4 set to manually installed.
==> default: libfreetype6 is already the newest version.
==> default: libfreetype6 set to manually installed.
==> default: libgd3 is already the newest version.
==> default: libgd3 set to manually installed.
==> default: libpng12-0 is already the newest version.
==> default: The following extra packages will be installed:
==> default:   libexpat1-dev libfontconfig1-dev libice-dev libjbig-dev libjpeg-turbo8-dev
==> default:   liblzma-dev libpthread-stubs0-dev libsm-dev libtiff5-dev libtiffxx5
==> default:   libvpx-dev libx11-dev libx11-doc libxau-dev libxcb1-dev libxdmcp-dev
==> default:   libxpm-dev libxt-dev pkg-config x11proto-core-dev x11proto-input-dev
==> default:   x11proto-kb-dev xorg-sgml-doctools xtrans-dev
==> default: Suggested packages:
==> default:   libice-doc liblzma-doc libsm-doc libxcb-doc libxt-doc
==> default: The following NEW packages will be installed:
==> default:   libexpat1-dev libfontconfig1-dev libfreetype6-dev libgd-dev libice-dev
==> default:   libjbig-dev libjpeg-dev libjpeg-turbo8-dev libjpeg8-dev liblzma-dev
==> default:   libpng12-dev libpthread-stubs0-dev libsm-dev libtiff5-dev libtiffxx5
==> default:   libvpx-dev libx11-dev libx11-doc libxau-dev libxcb1-dev libxdmcp-dev
==> default:   libxpm-dev libxt-dev pkg-config x11proto-core-dev x11proto-input-dev
==> default:   x11proto-kb-dev xorg-sgml-doctools xtrans-dev
==> default: 0 upgraded, 29 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 7,204 kB of archives.
==> default: After this operation, 32.6 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libtiffxx5 amd64 4.0.3-7ubuntu0.4 [5,634 B]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libjbig-dev amd64 2.0-2ubuntu4.1 [6,268 B]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libexpat1-dev amd64 2.1.0-4ubuntu1.3 [115 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libpng12-dev amd64 1.2.50-1ubuntu2.14.04.2 [206 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libfreetype6-dev amd64 2.5.2-1ubuntu2.5 [621 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main pkg-config amd64 0.26-1ubuntu4 [40.9 kB]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libfontconfig1-dev amd64 2.11.0-0ubuntu4.2 [665 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg-turbo8-dev amd64 1.3.0-0ubuntu2 [242 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg8-dev amd64 8c-2ubuntu8 [1,552 B]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg-dev amd64 8c-2ubuntu8 [1,546 B]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty/main xorg-sgml-doctools all 1:1.11-1 [12.9 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty-updates/main x11proto-core-dev all 7.0.26-1~ubuntu2 [700 kB]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty/main libxau-dev amd64 1:1.0.8-1 [11.1 kB]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty/main libxdmcp-dev amd64 1:1.1.1-1 [26.9 kB]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty/main x11proto-input-dev all 2.3-1 [139 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/main x11proto-kb-dev all 1.0.6-2 [269 kB]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty-updates/main xtrans-dev all 1.3.5-1~ubuntu14.04.1 [70.3 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/main libpthread-stubs0-dev amd64 0.3-4 [4,068 B]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/main libxcb1-dev amd64 1.10-2ubuntu1 [76.6 kB]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty/main libx11-dev amd64 2:1.6.2-1ubuntu2 [629 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/main libxpm-dev amd64 1:3.5.10-1 [94.2 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/main libice-dev amd64 2:1.0.8-2 [57.6 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/main libsm-dev amd64 2:1.2.1-2 [19.9 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/main libxt-dev amd64 1:1.1.4-1 [455 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty/main libvpx-dev amd64 1.3.0-2 [635 kB]
==> default: Get:26 http://archive.ubuntu.com/ubuntu/ trusty/main liblzma-dev amd64 5.1.1alpha+20120614-2ubuntu2 [137 kB]
==> default: Get:27 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libtiff5-dev amd64 4.0.3-7ubuntu0.4 [263 kB]
==> default: Get:28 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgd-dev amd64 2.1.0-3ubuntu0.5 [250 kB]
==> default: Get:29 http://archive.ubuntu.com/ubuntu/ trusty/main libx11-doc all 2:1.6.2-1ubuntu2 [1,448 kB]
==> default: Fetched 7,204 kB in 20s (350 kB/s)
==> default: Selecting previously unselected package libtiffxx5:amd64.
==> default: (Reading database ... 69684 files and directories currently installed.)
==> default: Preparing to unpack .../libtiffxx5_4.0.3-7ubuntu0.4_amd64.deb ...
==> default: Unpacking libtiffxx5:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Selecting previously unselected package libjbig-dev:amd64.
==> default: Preparing to unpack .../libjbig-dev_2.0-2ubuntu4.1_amd64.deb ...
==> default: Unpacking libjbig-dev:amd64 (2.0-2ubuntu4.1) ...
==> default: Selecting previously unselected package libexpat1-dev:amd64.
==> default: Preparing to unpack .../libexpat1-dev_2.1.0-4ubuntu1.3_amd64.deb ...
==> default: Unpacking libexpat1-dev:amd64 (2.1.0-4ubuntu1.3) ...
==> default: Selecting previously unselected package libpng12-dev.
==> default: Preparing to unpack .../libpng12-dev_1.2.50-1ubuntu2.14.04.2_amd64.deb ...
==> default: Unpacking libpng12-dev (1.2.50-1ubuntu2.14.04.2) ...
==> default: Selecting previously unselected package libfreetype6-dev.
==> default: Preparing to unpack .../libfreetype6-dev_2.5.2-1ubuntu2.5_amd64.deb ...
==> default: Unpacking libfreetype6-dev (2.5.2-1ubuntu2.5) ...
==> default: Selecting previously unselected package pkg-config.
==> default: Preparing to unpack .../pkg-config_0.26-1ubuntu4_amd64.deb ...
==> default: Unpacking pkg-config (0.26-1ubuntu4) ...
==> default: Selecting previously unselected package libfontconfig1-dev.
==> default: Preparing to unpack .../libfontconfig1-dev_2.11.0-0ubuntu4.2_amd64.deb ...
==> default: Unpacking libfontconfig1-dev (2.11.0-0ubuntu4.2) ...
==> default: Selecting previously unselected package libjpeg-turbo8-dev:amd64.
==> default: Preparing to unpack .../libjpeg-turbo8-dev_1.3.0-0ubuntu2_amd64.deb ...
==> default: Unpacking libjpeg-turbo8-dev:amd64 (1.3.0-0ubuntu2) ...
==> default: Selecting previously unselected package libjpeg8-dev:amd64.
==> default: Preparing to unpack .../libjpeg8-dev_8c-2ubuntu8_amd64.deb ...
==> default: Unpacking libjpeg8-dev:amd64 (8c-2ubuntu8) ...
==> default: Selecting previously unselected package libjpeg-dev:amd64.
==> default: Preparing to unpack .../libjpeg-dev_8c-2ubuntu8_amd64.deb ...
==> default: Unpacking libjpeg-dev:amd64 (8c-2ubuntu8) ...
==> default: Selecting previously unselected package xorg-sgml-doctools.
==> default: Preparing to unpack .../xorg-sgml-doctools_1%3a1.11-1_all.deb ...
==> default: Unpacking xorg-sgml-doctools (1:1.11-1) ...
==> default: Selecting previously unselected package x11proto-core-dev.
==> default: Preparing to unpack .../x11proto-core-dev_7.0.26-1~ubuntu2_all.deb ...
==> default: Unpacking x11proto-core-dev (7.0.26-1~ubuntu2) ...
==> default: Selecting previously unselected package libxau-dev:amd64.
==> default: Preparing to unpack .../libxau-dev_1%3a1.0.8-1_amd64.deb ...
==> default: Unpacking libxau-dev:amd64 (1:1.0.8-1) ...
==> default: Selecting previously unselected package libxdmcp-dev:amd64.
==> default: Preparing to unpack .../libxdmcp-dev_1%3a1.1.1-1_amd64.deb ...
==> default: Unpacking libxdmcp-dev:amd64 (1:1.1.1-1) ...
==> default: Selecting previously unselected package x11proto-input-dev.
==> default: Preparing to unpack .../x11proto-input-dev_2.3-1_all.deb ...
==> default: Unpacking x11proto-input-dev (2.3-1) ...
==> default: Selecting previously unselected package x11proto-kb-dev.
==> default: Preparing to unpack .../x11proto-kb-dev_1.0.6-2_all.deb ...
==> default: Unpacking x11proto-kb-dev (1.0.6-2) ...
==> default: Selecting previously unselected package xtrans-dev.
==> default: Preparing to unpack .../xtrans-dev_1.3.5-1~ubuntu14.04.1_all.deb ...
==> default: Unpacking xtrans-dev (1.3.5-1~ubuntu14.04.1) ...
==> default: Selecting previously unselected package libpthread-stubs0-dev:amd64.
==> default: Preparing to unpack .../libpthread-stubs0-dev_0.3-4_amd64.deb ...
==> default: Unpacking libpthread-stubs0-dev:amd64 (0.3-4) ...
==> default: Selecting previously unselected package libxcb1-dev:amd64.
==> default: Preparing to unpack .../libxcb1-dev_1.10-2ubuntu1_amd64.deb ...
==> default: Unpacking libxcb1-dev:amd64 (1.10-2ubuntu1) ...
==> default: Selecting previously unselected package libx11-dev:amd64.
==> default: Preparing to unpack .../libx11-dev_2%3a1.6.2-1ubuntu2_amd64.deb ...
==> default: Unpacking libx11-dev:amd64 (2:1.6.2-1ubuntu2) ...
==> default: Selecting previously unselected package libxpm-dev:amd64.
==> default: Preparing to unpack .../libxpm-dev_1%3a3.5.10-1_amd64.deb ...
==> default: Unpacking libxpm-dev:amd64 (1:3.5.10-1) ...
==> default: Selecting previously unselected package libice-dev:amd64.
==> default: Preparing to unpack .../libice-dev_2%3a1.0.8-2_amd64.deb ...
==> default: Unpacking libice-dev:amd64 (2:1.0.8-2) ...
==> default: Selecting previously unselected package libsm-dev:amd64.
==> default: Preparing to unpack .../libsm-dev_2%3a1.2.1-2_amd64.deb ...
==> default: Unpacking libsm-dev:amd64 (2:1.2.1-2) ...
==> default: Selecting previously unselected package libxt-dev:amd64.
==> default: Preparing to unpack .../libxt-dev_1%3a1.1.4-1_amd64.deb ...
==> default: Unpacking libxt-dev:amd64 (1:1.1.4-1) ...
==> default: Selecting previously unselected package libvpx-dev:amd64.
==> default: Preparing to unpack .../libvpx-dev_1.3.0-2_amd64.deb ...
==> default: Unpacking libvpx-dev:amd64 (1.3.0-2) ...
==> default: Selecting previously unselected package liblzma-dev:amd64.
==> default: Preparing to unpack .../liblzma-dev_5.1.1alpha+20120614-2ubuntu2_amd64.deb ...
==> default: Unpacking liblzma-dev:amd64 (5.1.1alpha+20120614-2ubuntu2) ...
==> default: Selecting previously unselected package libtiff5-dev:amd64.
==> default: Preparing to unpack .../libtiff5-dev_4.0.3-7ubuntu0.4_amd64.deb ...
==> default: Unpacking libtiff5-dev:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Selecting previously unselected package libgd-dev:amd64.
==> default: Preparing to unpack .../libgd-dev_2.1.0-3ubuntu0.5_amd64.deb ...
==> default: Unpacking libgd-dev:amd64 (2.1.0-3ubuntu0.5) ...
==> default: Selecting previously unselected package libx11-doc.
==> default: Preparing to unpack .../libx11-doc_2%3a1.6.2-1ubuntu2_all.deb ...
==> default: Unpacking libx11-doc (2:1.6.2-1ubuntu2) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libtiffxx5:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Setting up libjbig-dev:amd64 (2.0-2ubuntu4.1) ...
==> default: Setting up libexpat1-dev:amd64 (2.1.0-4ubuntu1.3) ...
==> default: Setting up libpng12-dev (1.2.50-1ubuntu2.14.04.2) ...
==> default: Setting up libfreetype6-dev (2.5.2-1ubuntu2.5) ...
==> default: Setting up pkg-config (0.26-1ubuntu4) ...
==> default: Setting up libfontconfig1-dev (2.11.0-0ubuntu4.2) ...
==> default: Setting up libjpeg-turbo8-dev:amd64 (1.3.0-0ubuntu2) ...
==> default: Setting up libjpeg8-dev:amd64 (8c-2ubuntu8) ...
==> default: Setting up libjpeg-dev:amd64 (8c-2ubuntu8) ...
==> default: Setting up xorg-sgml-doctools (1:1.11-1) ...
==> default: Setting up x11proto-core-dev (7.0.26-1~ubuntu2) ...
==> default: Setting up libxau-dev:amd64 (1:1.0.8-1) ...
==> default: Setting up libxdmcp-dev:amd64 (1:1.1.1-1) ...
==> default: Setting up x11proto-input-dev (2.3-1) ...
==> default: Setting up x11proto-kb-dev (1.0.6-2) ...
==> default: Setting up xtrans-dev (1.3.5-1~ubuntu14.04.1) ...
==> default: Setting up libpthread-stubs0-dev:amd64 (0.3-4) ...
==> default: Setting up libxcb1-dev:amd64 (1.10-2ubuntu1) ...
==> default: Setting up libx11-dev:amd64 (2:1.6.2-1ubuntu2) ...
==> default: Setting up libxpm-dev:amd64 (1:3.5.10-1) ...
==> default: Setting up libice-dev:amd64 (2:1.0.8-2) ...
==> default: Setting up libsm-dev:amd64 (2:1.2.1-2) ...
==> default: Setting up libxt-dev:amd64 (1:1.1.4-1) ...
==> default: Setting up libvpx-dev:amd64 (1.3.0-2) ...
==> default: Setting up liblzma-dev:amd64 (5.1.1alpha+20120614-2ubuntu2) ...
==> default: Setting up libtiff5-dev:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Setting up libgd-dev:amd64 (2.1.0-3ubuntu0.5) ...
==> default: Setting up libx11-doc (2:1.6.2-1ubuntu2) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libssl-dev is already the newest version.
==> default: libssl-dev set to manually installed.
==> default: openssl is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: gettext is already the newest version.
==> default: gettext set to manually installed.
==> default: libgettextpo-dev is already the newest version.
==> default: libgettextpo-dev set to manually installed.
==> default: libgettextpo0 is already the newest version.
==> default: libgettextpo0 set to manually installed.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: php5-cli is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   libmcrypt4
==> default: Suggested packages:
==> default:   mcrypt
==> default: The following NEW packages will be installed:
==> default:   libmcrypt-dev libmcrypt4
==> default: 0 upgraded, 2 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 145 kB of archives.
==> default: After this operation, 655 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/universe libmcrypt4 amd64 2.5.8-3.1ubuntu1 [61.9 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/universe libmcrypt-dev amd64 2.5.8-3.1ubuntu1 [83.1 kB]
==> default: Fetched 145 kB in 3s (36.5 kB/s)
==> default: Selecting previously unselected package libmcrypt4.
==> default: (Reading database ... 71933 files and directories currently installed.)
==> default: Preparing to unpack .../libmcrypt4_2.5.8-3.1ubuntu1_amd64.deb ...
==> default: Unpacking libmcrypt4 (2.5.8-3.1ubuntu1) ...
==> default: Selecting previously unselected package libmcrypt-dev.
==> default: Preparing to unpack .../libmcrypt-dev_2.5.8-3.1ubuntu1_amd64.deb ...
==> default: Unpacking libmcrypt-dev (2.5.8-3.1ubuntu1) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libmcrypt4 (2.5.8-3.1ubuntu1) ...
==> default: Setting up libmcrypt-dev (2.5.8-3.1ubuntu1) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libreadline-dev is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: /home/vagrant
==> default: # WARNING: curl extension might be required for fetching data.
==> default: Using root: /root/.phpbrew
==> default: Initialization successfully finished!
==> default: <=====================================================>
==> default: Phpbrew environment is initialized, required directories are created under
==> default: 
==> default:     /root/.phpbrew
==> default: 
==> default: Paste the following line(s) to the end of your ~/.bashrc and start a
==> default: new shell, phpbrew should be up and fully functional from there:
==> default: 
==> default:     source /root/.phpbrew/bashrc
==> default: 
==> default: To enable PHP version info in your shell prompt, please set PHPBREW_SET_PROMPT=1
==> default: in your `~/.bashrc` before you source `~/.phpbrew/bashrc`
==> default: 
==> default:     export PHPBREW_SET_PROMPT=1
==> default: 
==> default: To enable .phpbrewrc file searching, please export the following variable:
==> default: 
==> default:     export PHPBREW_RC_ENABLE=1
==> default: 
==> default: 
==> default: For further instructions, simply run `phpbrew` to see the help message.
==> default: 
==> default: Enjoy phpbrew at $HOME!!
==> default: <=====================================================>
==> default: # WARNING: curl extension might be required for fetching data.
==> default: ===> Fetching release list...
==> default: Downloading https://secure.php.net/releases/index.php?json&version=7&max=100 via php stream
==> default: Downloading https://secure.php.net/releases/index.php?json&version=5&max=100 via php stream
==> default: 7.1: 7.1.0 ...
==> default: 7.0: 7.0.14, 7.0.13, 7.0.12, 7.0.11, 7.0.10, 7.0.9, 7.0.8, 7.0.7 ...
==> default: 5.6: 5.6.29, 5.6.28, 5.6.27, 5.6.26, 5.6.25, 5.6.24, 5.6.23, 5.6.22 ...
==> default: 5.5: 5.5.38, 5.5.37, 5.5.36, 5.5.35, 5.5.34, 5.5.33, 5.5.32, 5.5.31 ...
==> default: 5.4: 5.4.45, 5.4.44, 5.4.43, 5.4.42, 5.4.41, 5.4.40, 5.4.39, 5.4.38 ...
==> default: # WARNING: curl extension might be required for fetching data.
==> default: ===> Fetching release list...
==> default: Downloading https://secure.php.net/releases/index.php?json&version=7&max=100 via php stream
==> default: Downloading https://secure.php.net/releases/index.php?json&version=5&max=100 via php stream
==> default: 7.1: 1 releases
==> default: 7.0: 15 releases
==> default: 5.6: 30 releases
==> default: 5.5: 39 releases
==> default: 5.4: 31 releases
==> default: ===> Done
==> default: # WARNING: curl extension might be required for fetching data.
==> default: *WARNING* You're runing phpbrew as root/sudo. Unless you're going to install
==> default: system-wide phpbrew or this might cause problems.
==> default: ===> phpbrew will now build 5.4.34
==> default: ===> Loading and resolving variants...
==> default: Downloading http://www.php.net/get/php-5.4.34.tar.bz2/from/this/mirror via php stream
==> default: ===> Extracting /root/.phpbrew/distfiles/php-5.4.34.tar.bz2 to /root/.phpbrew/build/tmp.1484674902/php-5.4.34
==> default: ===> Moving /root/.phpbrew/build/tmp.1484674902/php-5.4.34 to /root/.phpbrew/build/php-5.4.34
==> default: ===> Checking patches...
==> default: Checking patch for replace apache php module name with custom version name
==> default: ===> Configuring 5.4.34...
==> default: 
==> default: Use tail command to see what's going on:
==> default:    $ tail -F /root/.phpbrew/build/php-5.4.34/build.log
==> default: ===> Checking patches...
==> default: Checking patch for php5.3.29 multi-sapi patch.
==> default: Checking patch for php5.3.x on 64bit machine when intl is enabled.
==> default: Checking patch for openssl dso linking patch
==> default: ===> Building...
==> default: Build finished: 3.1 minutes.
==> default: Installing...
==> default: ---> Creating php-fpm.conf
==> default: ---> Creating php.ini
==> default: ---> Copying /root/.phpbrew/build/php-5.4.34/php.ini-development 
==> default: ---> Found date.timezone is not set, patching...
==> default: Congratulations! Now you have PHP with 5.4.34 as php-5.4.34
==> default: 
==> default: * To configure your installed PHP further, you can edit the config file at
==> default:     /root/.phpbrew/php/php-5.4.34/etc/php.ini
==> default: 
==> default: * WARNING:
==> default:   You haven't setup your .bashrc file to load phpbrew shell script yet!
==> default:   Please run 'phpbrew init' to see the steps!
==> default: 
==> default: To use the newly built PHP, try the line(s) below:
==> default: 
==> default:     $ phpbrew use php-5.4.34
==> default: 
==> default: Or you can use switch command to switch your default php to php-5.4.34:
==> default: 
==> default:     $ phpbrew switch php-5.4.34
==> default: 
==> default: Enjoy!
==> default: # WARNING: curl extension might be required for fetching data.
==> default: Invalid argument php-5.4.34
==> default: # WARNING: curl extension might be required for fetching data.
==> default: Error: PHPBREW_PHP environment variable is not defined.
==> default:   This extension command requires you specify a PHP version from your build list.
==> default:   And it looks like you haven't switched to a version from the builds that were built with PHPBrew.
==> default: Suggestion: Please install at least one PHP with your prefered version and switch to it.
==> default: All settings correct for using Composer
==> default: Downloading...
==> default: 
==> default: Composer (version 1.3.1) successfully installed to: /home/vagrant/project/integration-tests/composer.phar
==> default: Use it: php composer.phar
==> default: Do not run Composer as root/super user! See https://getcomposer.org/root for details
==> default: Loading composer repositories with package information
==> default: Updating dependencies (including require-dev)
==> default: Package operations: 18 installs, 0 updates, 0 removals
==> default:   - Installing psr/log (1.0.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing monolog/monolog (1.22.0)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing predis/predis (v1.0.4)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing symfony/yaml (v2.8.16)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/version (1.0.6)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/recursion-context (1.0.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/exporter (1.2.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/environment (1.3.8)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/diff (1.4.1)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/comparator (1.2.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing doctrine/instantiator (1.0.5)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-text-template (1.2.1)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/phpunit-mock-objects (2.3.8)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-timer (1.0.8)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-file-iterator (1.3.4)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-token-stream (1.4.9)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-code-coverage (2.2.4)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/phpunit (4.3.5)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default: monolog/monolog suggests installing aws/aws-sdk-php (Allow sending log messages to AWS services like DynamoDB)
==> default: monolog/monolog suggests installing doctrine/couchdb (Allow sending log messages to a CouchDB server)
==> default: monolog/monolog suggests installing ext-amqp (Allow sending log messages to an AMQP server (1.0+ required))
==> default: monolog/monolog suggests installing ext-mongo (Allow sending log messages to a MongoDB server)
==> default: monolog/monolog suggests installing graylog2/gelf-php (Allow sending log messages to a GrayLog2 server)
==> default: monolog/monolog suggests installing mongodb/mongodb (Allow sending log messages to a MongoDB server via PHP Driver)
==> default: monolog/monolog suggests installing php-amqplib/php-amqplib (Allow sending log messages to an AMQP server using php-amqplib)
==> default: monolog/monolog suggests installing php-console/php-console (Allow sending log messages to Google Chrome)
==> default: monolog/monolog suggests installing rollbar/rollbar (Allow sending log messages to Rollbar)
==> default: monolog/monolog suggests installing ruflin/elastica (Allow sending log messages to an Elastic Search server)
==> default: monolog/monolog suggests installing sentry/sentry (Allow sending log messages to a Sentry server)
==> default: predis/predis suggests installing ext-phpiredis (Allows faster serialization and deserialization of the Redis protocol)
==> default: predis/predis suggests installing ext-curl (Allows access to Webdis when paired with phpiredis)
==> default: phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
==> default: Writing lock file
==> default: Generating autoload files
Welcome to Ubuntu 14.04.5 LTS (GNU/Linux 3.13.0-105-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Tue Jan 17 17:36:40 UTC 2017

  System load:  0.73              Processes:           82
  Usage of /:   3.6% of 39.34GB   Users logged in:     0
  Memory usage: 6%                IP address for eth0: 10.0.2.15
  Swap usage:   0%

  Graph this data and manage this system at:
    https://landscape.canonical.com/

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

0 packages can be updated.
0 updates are security updates.

New release '16.04.1 LTS' available.
Run 'do-release-upgrade' to upgrade to it.


-bash: /root/.phpbrew/bashrc: Permission denied
```

# php54 is not linked
```
vagrant@vagrant-ubuntu-trusty-64:~$ php -v
PHP 5.5.9-1ubuntu4.20 (cli) (built: Oct  3 2016 13:00:37) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies
    with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans
```

# phpbrew switch fails
```
vagrant@vagrant-ubuntu-trusty-64:~$ phpbrew switch 5.4.34
# WARNING: curl extension might be required for fetching data.
PHP Fatal error:  Class 'PhpBrew\Exception' not found in phar:///usr/bin/phpbrew/src/PhpBrew/BuildFinder.php on line 14
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpbrew:0
PHP   2. require() /usr/bin/phpbrew:99
PHP   3. PhpBrew\Console->runWithTry() phar:///usr/bin/phpbrew/scripts/phpbrew-emb.php:2
PHP   4. CLIFramework\Application->run() phar:///usr/bin/phpbrew/src/PhpBrew/Console.php:114
PHP   5. CLIFramework\CommandBase->executeWrapper() phar:///usr/bin/phpbrew/vendor/corneltek/cliframework/src/Application.php:398
PHP   6. CLIFramework\ArgInfo->validate() phar:///usr/bin/phpbrew/vendor/corneltek/cliframework/src/CommandBase.php:806
PHP   7. CLIFramework\ArgInfo->getValidValues() phar:///usr/bin/phpbrew/vendor/corneltek/cliframework/src/ArgInfo.php:119
PHP   8. call_user_func() phar:///usr/bin/phpbrew/vendor/corneltek/cliframework/src/ArgInfo.php:99
PHP   9. PhpBrew\Command\SwitchCommand->PhpBrew\Command\{closure}() phar:///usr/bin/phpbrew/vendor/corneltek/cliframework/src/ArgInfo.php:99
PHP  10. PhpBrew\BuildFinder::findMatchedBuilds() phar:///usr/bin/phpbrew/src/PhpBrew/Command/SwitchCommand.php:16
PHP  11. PhpBrew\BuildFinder::findInstalledBuilds() phar:///usr/bin/phpbrew/src/PhpBrew/BuildFinder.php:39
```

# switch user to root, source bashrc and switch php to php54
```
vagrant@vagrant-ubuntu-trusty-64:~/project/integration-tests$ sudo su
root@vagrant-ubuntu-trusty-64:/home/vagrant/project/integration-tests# phpbrew switch 5.4.34
# WARNING: curl extension might be required for fetching data.
You should not see this, if you see this, it means you didn't load the ~/.phpbrew/bashrc script, please check if bashrc is sourced in your shell.
root@vagrant-ubuntu-trusty-64:/home/vagrant/project/integration-tests# source ~/.phpbrew/bashrc
root@vagrant-ubuntu-trusty-64:/home/vagrant/project/integration-tests# phpbrew switch 5.4.34
root@vagrant-ubuntu-trusty-64:/home/vagrant/project/integration-tests# php -v
PHP 5.4.34 (cli) (built: Jan 17 2017 17:45:02) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.4.0, Copyright (c) 1998-2014 Zend Technologies
```

# run integration tests as root
```
root@vagrant-ubuntu-trusty-64:/home/vagrant/project/integration-tests# vendor/bin/phpunit LDDFeatureRequesterTest.php 
PHPUnit 4.3.5 by Sebastian Bergmann.

PHP Parse error:  syntax error, unexpected 'class' (T_CLASS), expecting identifier (T_STRING) or variable (T_VARIABLE) or '{' or '$' in /home/vagrant/project/src/LaunchDarkly/LDClient.php on line 91

Parse error: syntax error, unexpected 'class' (T_CLASS), expecting identifier (T_STRING) or variable (T_VARIABLE) or '{' or '$' in /home/vagrant/project/src/LaunchDarkly/LDClient.php on line 91
```

# `::class` is not available in php54, which explains that change in my request
```
root@vagrant-ubuntu-trusty-64:/home/vagrant/project/integration-tests# vendor/bin/phpunit LDDFeatureRequesterTest.php 
PHPUnit 4.3.5 by Sebastian Bergmann.

EPHP Fatal error:  Call to undefined function LaunchDarkly\apc_fetch() in /home/vagrant/project/src/LaunchDarkly/ApcLDDFeatureRequester.php on line 24

Fatal error: Call to undefined function LaunchDarkly\apc_fetch() in /home/vagrant/project/src/LaunchDarkly/ApcLDDFeatureRequester.php on line 24
```

# php54-apc is not installed, because the provisioner switch did not work
```
root@vagrant-ubuntu-trusty-64:/home/vagrant/project/integration-tests# php -m
[PHP Modules]
bcmath
bz2
calendar
Core
ctype
date
dom
ereg
fileinfo
filter
hash
json
libxml
mbstring
mcrypt
mhash
openssl
pcntl
pcre
PDO
Phar
posix
readline
Reflection
session
shmop
SimpleXML
sockets
SPL
standard
sysvmsg
sysvsem
sysvshm
tokenizer
xml
xmlreader
xmlwriter
xsl
zip
zlib

[Zend Modules]
```

# with my change, the integration tests pass when run as the `vagrant` user immediately after running `vagrant ssh`. no assembly required : )
```
✔ ~/github.com/launchdarkly/php-client/integration-tests [update-provisioner-2 L|●1✚ 4] 
09:23 $ rm -rf composer.lock vendor/
✔ ~/github.com/launchdarkly/php-client/integration-tests [update-provisioner-2 L|●1✚ 4] 
09:23 $ vagrant destroy && vagrant up && vagrant ssh
    default: Are you sure you want to destroy the 'default' VM? [y/N] y
==> default: Forcing shutdown of VM...
==> default: Destroying VM and associated drives...
==> default: [vagrant-hostsupdater] Removing hosts
==> default: Running cleanup tasks for 'shell' provisioner...
==> default: Running cleanup tasks for 'shell' provisioner...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/trusty64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/trusty64' is up to date...
==> default: A newer version of the box 'ubuntu/trusty64' is available! You currently
==> default: have version '20161214.0.0'. The latest is version '20170110.0.0'. Run
==> default: `vagrant box update` to update.
==> default: Setting the name of the VM: integration-tests_default_1484670258263_65069
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 => 2200 (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 4.3.36
    default: VirtualBox Version: 5.0
==> default: [vagrant-hostsupdater] Checking for host entries
==> default: Mounting shared folders...
    default: /vagrant => /Users/tyounger/github.com/launchdarkly/php-client/integration-tests
    default: /home/vagrant/project => /Users/tyounger/github.com/launchdarkly/php-client
==> default: Running provisioner: shell...
    default: Running: /var/folders/gk/qkjjk8zs32v4jrg3k3xgf7h5y_y_66/T/vagrant-shell20170117-60197-ahl10a.sh
==> default: stdin: is not a tty
==> default: Get:1 http://security.ubuntu.com trusty-security InRelease [65.9 kB]
==> default: Ign http://archive.ubuntu.com trusty InRelease
==> default: Get:2 http://archive.ubuntu.com trusty-updates InRelease [65.9 kB]
==> default: Get:3 http://security.ubuntu.com trusty-security/main Sources [123 kB]
==> default: Get:4 http://archive.ubuntu.com trusty-backports InRelease [65.9 kB]
==> default: Get:5 http://security.ubuntu.com trusty-security/universe Sources [47.3 kB]
==> default: Hit http://archive.ubuntu.com trusty Release.gpg
==> default: Get:6 http://security.ubuntu.com trusty-security/main amd64 Packages [573 kB]
==> default: Get:7 http://archive.ubuntu.com trusty-updates/main Sources [388 kB]
==> default: Get:8 http://security.ubuntu.com trusty-security/universe amd64 Packages [148 kB]
==> default: Get:9 http://security.ubuntu.com trusty-security/main Translation-en [317 kB]
==> default: Get:10 http://archive.ubuntu.com trusty-updates/restricted Sources [5,888 B]
==> default: Get:11 http://archive.ubuntu.com trusty-updates/universe Sources [171 kB]
==> default: Get:12 http://security.ubuntu.com trusty-security/universe Translation-en [87.2 kB]
==> default: Get:13 http://archive.ubuntu.com trusty-updates/multiverse Sources [7,535 B]
==> default: Get:14 http://archive.ubuntu.com trusty-updates/main amd64 Packages [938 kB]
==> default: Get:15 http://archive.ubuntu.com trusty-updates/restricted amd64 Packages [16.4 kB]
==> default: Get:16 http://archive.ubuntu.com trusty-updates/universe amd64 Packages [392 kB]
==> default: Get:17 http://archive.ubuntu.com trusty-updates/multiverse amd64 Packages [14.0 kB]
==> default: Get:18 http://archive.ubuntu.com trusty-updates/main Translation-en [460 kB]
==> default: Get:19 http://archive.ubuntu.com trusty-updates/multiverse Translation-en [7,340 B]
==> default: Get:20 http://archive.ubuntu.com trusty-updates/restricted Translation-en [3,842 B]
==> default: Get:21 http://archive.ubuntu.com trusty-updates/universe Translation-en [208 kB]
==> default: Get:22 http://archive.ubuntu.com trusty-backports/main Sources [9,636 B]
==> default: Get:23 http://archive.ubuntu.com trusty-backports/restricted Sources [28 B]
==> default: Get:24 http://archive.ubuntu.com trusty-backports/universe Sources [35.3 kB]
==> default: Get:25 http://archive.ubuntu.com trusty-backports/multiverse Sources [1,898 B]
==> default: Get:26 http://archive.ubuntu.com trusty-backports/main amd64 Packages [13.3 kB]
==> default: Get:27 http://archive.ubuntu.com trusty-backports/restricted amd64 Packages [28 B]
==> default: Get:28 http://archive.ubuntu.com trusty-backports/universe amd64 Packages [43.2 kB]
==> default: Get:29 http://archive.ubuntu.com trusty-backports/multiverse amd64 Packages [1,571 B]
==> default: Get:30 http://archive.ubuntu.com trusty-backports/main Translation-en [7,493 B]
==> default: Get:31 http://archive.ubuntu.com trusty-backports/multiverse Translation-en [1,215 B]
==> default: Get:32 http://archive.ubuntu.com trusty-backports/restricted Translation-en [28 B]
==> default: Get:33 http://archive.ubuntu.com trusty-backports/universe Translation-en [36.8 kB]
==> default: Hit http://archive.ubuntu.com trusty Release
==> default: Get:34 http://archive.ubuntu.com trusty/main Sources [1,064 kB]
==> default: Get:35 http://archive.ubuntu.com trusty/restricted Sources [5,433 B]
==> default: Get:36 http://archive.ubuntu.com trusty/universe Sources [6,399 kB]
==> default: Get:37 http://archive.ubuntu.com trusty/multiverse Sources [174 kB]
==> default: Hit http://archive.ubuntu.com trusty/main amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/restricted amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/universe amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/multiverse amd64 Packages
==> default: Hit http://archive.ubuntu.com trusty/main Translation-en
==> default: Hit http://archive.ubuntu.com trusty/multiverse Translation-en
==> default: Hit http://archive.ubuntu.com trusty/restricted Translation-en
==> default: Hit http://archive.ubuntu.com trusty/universe Translation-en
==> default: Ign http://archive.ubuntu.com trusty/main Translation-en_US
==> default: Ign http://archive.ubuntu.com trusty/multiverse Translation-en_US
==> default: Ign http://archive.ubuntu.com trusty/restricted Translation-en_US
==> default: Ign http://archive.ubuntu.com trusty/universe Translation-en_US
==> default: Fetched 11.9 MB in 14s (824 kB/s)
==> default: Reading package lists...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   libjemalloc1 redis-tools
==> default: The following NEW packages will be installed:
==> default:   libjemalloc1 redis-server redis-tools
==> default: 0 upgraded, 3 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 410 kB of archives.
==> default: After this operation, 1,272 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/universe libjemalloc1 amd64 3.5.1-2 [76.8 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/universe redis-tools amd64 2:2.8.4-2 [65.7 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty/universe redis-server amd64 2:2.8.4-2 [267 kB]
==> default: Fetched 410 kB in 2s (184 kB/s)
==> default: Selecting previously unselected package libjemalloc1.
==> default: (Reading database ... 63024 files and directories currently installed.)
==> default: Preparing to unpack .../libjemalloc1_3.5.1-2_amd64.deb ...
==> default: Unpacking libjemalloc1 (3.5.1-2) ...
==> default: Selecting previously unselected package redis-tools.
==> default: Preparing to unpack .../redis-tools_2%3a2.8.4-2_amd64.deb ...
==> default: Unpacking redis-tools (2:2.8.4-2) ...
==> default: Selecting previously unselected package redis-server.
==> default: Preparing to unpack .../redis-server_2%3a2.8.4-2_amd64.deb ...
==> default: Unpacking redis-server (2:2.8.4-2) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Setting up libjemalloc1 (3.5.1-2) ...
==> default: Setting up redis-tools (2:2.8.4-2) ...
==> default: Setting up redis-server (2:2.8.4-2) ...
==> default: Starting redis-server: 
==> default: redis-server.
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   libopts25
==> default: Suggested packages:
==> default:   ntp-doc
==> default: The following NEW packages will be installed:
==> default:   libopts25 ntp
==> default: 0 upgraded, 2 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 477 kB of archives.
==> default: After this operation, 1,682 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libopts25 amd64 1:5.18-2ubuntu2 [55.3 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main ntp amd64 1:4.2.6.p5+dfsg-3ubuntu2.14.04.10 [421 kB]
==> default: Fetched 477 kB in 2s (168 kB/s)
==> default: Selecting previously unselected package libopts25:amd64.
==> default: (Reading database ... 63053 files and directories currently installed.)
==> default: Preparing to unpack .../libopts25_1%3a5.18-2ubuntu2_amd64.deb ...
==> default: Unpacking libopts25:amd64 (1:5.18-2ubuntu2) ...
==> default: Selecting previously unselected package ntp.
==> default: Preparing to unpack .../ntp_1%3a4.2.6.p5+dfsg-3ubuntu2.14.04.10_amd64.deb ...
==> default: Unpacking ntp (1:4.2.6.p5+dfsg-3ubuntu2.14.04.10) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libopts25:amd64 (1:5.18-2ubuntu2) ...
==> default: Setting up ntp (1:4.2.6.p5+dfsg-3ubuntu2.14.04.10) ...
==> default:  * Starting NTP server ntpd
==> default:    ...done.
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default:  * Stopping NTP server ntpd
==> default:    ...done.
==> default:  * Starting NTP server ntpd
==> default:    ...done.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: Suggested packages:
==> default:   zip
==> default: The following NEW packages will be installed:
==> default:   unzip
==> default: 0 upgraded, 1 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 157 kB of archives.
==> default: After this operation, 395 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main unzip amd64 6.0-9ubuntu1.5 [157 kB]
==> default: Fetched 157 kB in 0s (217 kB/s)
==> default: Selecting previously unselected package unzip.
==> default: (Reading database ... 63096 files and directories currently installed.)
==> default: Preparing to unpack .../unzip_6.0-9ubuntu1.5_amd64.deb ...
==> default: Unpacking unzip (6.0-9ubuntu1.5) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for mime-support (3.54ubuntu1.1) ...
==> default: Setting up unzip (6.0-9ubuntu1.5) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: curl is already the newest version.
==> default: vim is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   git-man liberror-perl
==> default: Suggested packages:
==> default:   git-daemon-run git-daemon-sysvinit git-doc git-el git-email git-gui gitk
==> default:   gitweb git-arch git-bzr git-cvs git-mediawiki git-svn
==> default: The following NEW packages will be installed:
==> default:   git git-man liberror-perl
==> default: 0 upgraded, 3 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 3,306 kB of archives.
==> default: After this operation, 21.9 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main liberror-perl all 0.17-1.1 [21.1 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main git-man all 1:1.9.1-1ubuntu0.3 [699 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main git amd64 1:1.9.1-1ubuntu0.3 [2,586 kB]
==> default: Fetched 3,306 kB in 1s (1,802 kB/s)
==> default: Selecting previously unselected package liberror-perl.
==> default: (Reading database ... 63114 files and directories currently installed.)
==> default: Preparing to unpack .../liberror-perl_0.17-1.1_all.deb ...
==> default: Unpacking liberror-perl (0.17-1.1) ...
==> default: Selecting previously unselected package git-man.
==> default: Preparing to unpack .../git-man_1%3a1.9.1-1ubuntu0.3_all.deb ...
==> default: Unpacking git-man (1:1.9.1-1ubuntu0.3) ...
==> default: Selecting previously unselected package git.
==> default: Preparing to unpack .../git_1%3a1.9.1-1ubuntu0.3_amd64.deb ...
==> default: Unpacking git (1:1.9.1-1ubuntu0.3) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up liberror-perl (0.17-1.1) ...
==> default: Setting up git-man (1:1.9.1-1ubuntu0.3) ...
==> default: Setting up git (1:1.9.1-1ubuntu0.3) ...
==> default: Install PHP things
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   php5-apcu php5-common php5-json
==> default: Suggested packages:
==> default:   php5-gd php5-user-cache
==> default: The following NEW packages will be installed:
==> default:   php-apc php5-apcu php5-common php5-json
==> default: 0 upgraded, 4 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 558 kB of archives.
==> default: After this operation, 1,662 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main php5-json amd64 1.3.2-2build1 [34.4 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-common amd64 5.5.9+dfsg-1ubuntu4.20 [447 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty/universe php5-apcu amd64 4.0.2-2build1 [73.2 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty/universe php-apc all 4.0.2-2build1 [2,762 B]
==> default: Fetched 558 kB in 14s (39.2 kB/s)
==> default: Selecting previously unselected package php5-json.
==> default: (Reading database ... 63862 files and directories currently installed.)
==> default: Preparing to unpack .../php5-json_1.3.2-2build1_amd64.deb ...
==> default: Unpacking php5-json (1.3.2-2build1) ...
==> default: Selecting previously unselected package php5-common.
==> default: Preparing to unpack .../php5-common_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-common (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php5-apcu.
==> default: Preparing to unpack .../php5-apcu_4.0.2-2build1_amd64.deb ...
==> default: Unpacking php5-apcu (4.0.2-2build1) ...
==> default: Selecting previously unselected package php-apc.
==> default: Preparing to unpack .../php-apc_4.0.2-2build1_all.deb ...
==> default: Unpacking php-apc (4.0.2-2build1) ...
==> default: Setting up php5-json (1.3.2-2build1) ...
==> default: Setting up php5-common (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up php5-apcu (4.0.2-2build1) ...
==> default: Setting up php-apc (4.0.2-2build1) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   apache2 apache2-bin apache2-data libapache2-mod-php5 libapr1 libaprutil1
==> default:   libaprutil1-dbd-sqlite3 libaprutil1-ldap pear-channels php-codecoverage
==> default:   php-file-iterator php-invoker php-pear php-symfony2-yaml php-text-template
==> default:   php-timer php-token-stream php5 php5-cli php5-readline php5-xdebug
==> default:   phpunit-mock-object phpunit-story ssl-cert
==> default: Suggested packages:
==> default:   apache2-doc apache2-suexec-pristine apache2-suexec-custom apache2-utils
==> default:   php5-dev phpunit-selenium openssl-blacklist
==> default: The following NEW packages will be installed:
==> default:   apache2 apache2-bin apache2-data libapache2-mod-php5 libapr1 libaprutil1
==> default:   libaprutil1-dbd-sqlite3 libaprutil1-ldap pear-channels php-codecoverage
==> default:   php-file-iterator php-invoker php-pear php-symfony2-yaml php-text-template
==> default:   php-timer php-token-stream php5 php5-cli php5-readline php5-xdebug phpunit
==> default:   phpunit-mock-object phpunit-story ssl-cert
==> default: 0 upgraded, 25 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 6,468 kB of archives.
==> default: After this operation, 30.4 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libapr1 amd64 1.5.0-1 [85.1 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1 amd64 1.5.3-1 [76.4 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-cli amd64 5.5.9+dfsg-1ubuntu4.20 [2,164 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-readline amd64 5.5.9+dfsg-1ubuntu4.20 [12.1 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1-dbd-sqlite3 amd64 1.5.3-1 [10.5 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main libaprutil1-ldap amd64 1.5.3-1 [8,634 B]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2-bin amd64 2.4.7-1ubuntu4.13 [839 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2-data all 2.4.7-1ubuntu4.13 [160 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty-updates/main apache2 amd64 2.4.7-1ubuntu4.13 [87.4 kB]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libapache2-mod-php5 amd64 5.5.9+dfsg-1ubuntu4.20 [2,210 kB]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php-pear all 5.5.9+dfsg-1ubuntu4.20 [267 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty/universe pear-channels all 0~20131124-1 [5,846 B]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5 all 5.5.9+dfsg-1ubuntu4.20 [1,306 B]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty/universe php-file-iterator all 1.3.1-2 [7,702 B]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty/universe php-token-stream all 1.1.3-2 [12.4 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/universe php-text-template all 1.1.1-2 [6,070 B]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty/universe php-codecoverage all 1.2.13+dfsg1-1 [76.5 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/universe php-timer all 1.0.5-1 [6,016 B]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/universe php-invoker all 1.1.0-1 [6,134 B]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty/universe php-symfony2-yaml all 2.4.1-1 [16.6 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/universe php5-xdebug amd64 2.2.3-2build1 [253 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit-mock-object all 1.2.3-1 [23.6 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit all 3.7.28-1 [104 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/universe phpunit-story all 1.0.0-3 [11.4 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty/main ssl-cert all 1.0.33 [16.6 kB]
==> default: Fetched 6,468 kB in 5s (1,149 kB/s)
==> default: Selecting previously unselected package libapr1:amd64.
==> default: (Reading database ... 63943 files and directories currently installed.)
==> default: Preparing to unpack .../libapr1_1.5.0-1_amd64.deb ...
==> default: Unpacking libapr1:amd64 (1.5.0-1) ...
==> default: Selecting previously unselected package libaprutil1:amd64.
==> default: Preparing to unpack .../libaprutil1_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package php5-cli.
==> default: Preparing to unpack .../php5-cli_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-cli (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php5-readline.
==> default: Preparing to unpack .../php5-readline_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-readline (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package libaprutil1-dbd-sqlite3:amd64.
==> default: Preparing to unpack .../libaprutil1-dbd-sqlite3_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1-dbd-sqlite3:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package libaprutil1-ldap:amd64.
==> default: Preparing to unpack .../libaprutil1-ldap_1.5.3-1_amd64.deb ...
==> default: Unpacking libaprutil1-ldap:amd64 (1.5.3-1) ...
==> default: Selecting previously unselected package apache2-bin.
==> default: Preparing to unpack .../apache2-bin_2.4.7-1ubuntu4.13_amd64.deb ...
==> default: Unpacking apache2-bin (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package apache2-data.
==> default: Preparing to unpack .../apache2-data_2.4.7-1ubuntu4.13_all.deb ...
==> default: Unpacking apache2-data (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package apache2.
==> default: Preparing to unpack .../apache2_2.4.7-1ubuntu4.13_amd64.deb ...
==> default: Unpacking apache2 (2.4.7-1ubuntu4.13) ...
==> default: Selecting previously unselected package libapache2-mod-php5.
==> default: Preparing to unpack .../libapache2-mod-php5_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking libapache2-mod-php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php-pear.
==> default: Preparing to unpack .../php-pear_5.5.9+dfsg-1ubuntu4.20_all.deb ...
==> default: Unpacking php-pear (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package pear-channels.
==> default: Preparing to unpack .../pear-channels_0~20131124-1_all.deb ...
==> default: Unpacking pear-channels (0~20131124-1) ...
==> default: Selecting previously unselected package php5.
==> default: Preparing to unpack .../php5_5.5.9+dfsg-1ubuntu4.20_all.deb ...
==> default: Unpacking php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package php-file-iterator.
==> default: Preparing to unpack .../php-file-iterator_1.3.1-2_all.deb ...
==> default: Unpacking php-file-iterator (1.3.1-2) ...
==> default: Selecting previously unselected package php-token-stream.
==> default: Preparing to unpack .../php-token-stream_1.1.3-2_all.deb ...
==> default: Unpacking php-token-stream (1.1.3-2) ...
==> default: Selecting previously unselected package php-text-template.
==> default: Preparing to unpack .../php-text-template_1.1.1-2_all.deb ...
==> default: Unpacking php-text-template (1.1.1-2) ...
==> default: Selecting previously unselected package php-codecoverage.
==> default: Preparing to unpack .../php-codecoverage_1.2.13+dfsg1-1_all.deb ...
==> default: Unpacking php-codecoverage (1.2.13+dfsg1-1) ...
==> default: Selecting previously unselected package php-timer.
==> default: Preparing to unpack .../php-timer_1.0.5-1_all.deb ...
==> default: Unpacking php-timer (1.0.5-1) ...
==> default: Selecting previously unselected package php-invoker.
==> default: Preparing to unpack .../php-invoker_1.1.0-1_all.deb ...
==> default: Unpacking php-invoker (1.1.0-1) ...
==> default: Selecting previously unselected package php-symfony2-yaml.
==> default: Preparing to unpack .../php-symfony2-yaml_2.4.1-1_all.deb ...
==> default: Unpacking php-symfony2-yaml (2.4.1-1) ...
==> default: Selecting previously unselected package php5-xdebug.
==> default: Preparing to unpack .../php5-xdebug_2.2.3-2build1_amd64.deb ...
==> default: Unpacking php5-xdebug (2.2.3-2build1) ...
==> default: Selecting previously unselected package phpunit-mock-object.
==> default: Preparing to unpack .../phpunit-mock-object_1.2.3-1_all.deb ...
==> default: Unpacking phpunit-mock-object (1.2.3-1) ...
==> default: Selecting previously unselected package phpunit.
==> default: Preparing to unpack .../phpunit_3.7.28-1_all.deb ...
==> default: Unpacking phpunit (3.7.28-1) ...
==> default: Selecting previously unselected package phpunit-story.
==> default: Preparing to unpack .../phpunit-story_1.0.0-3_all.deb ...
==> default: Unpacking phpunit-story (1.0.0-3) ...
==> default: Selecting previously unselected package ssl-cert.
==> default: Preparing to unpack .../ssl-cert_1.0.33_all.deb ...
==> default: Unpacking ssl-cert (1.0.33) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for ufw (0.34~rc-0ubuntu2) ...
==> default: Setting up libapr1:amd64 (1.5.0-1) ...
==> default: Setting up libaprutil1:amd64 (1.5.3-1) ...
==> default: Setting up php5-cli (5.5.9+dfsg-1ubuntu4.20) ...
==> default: update-alternatives: 
==> default: using /usr/bin/php5 to provide /usr/bin/php (php) in auto mode
==> default: Setting up php5-readline (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up libaprutil1-dbd-sqlite3:amd64 (1.5.3-1) ...
==> default: Setting up libaprutil1-ldap:amd64 (1.5.3-1) ...
==> default: Setting up apache2-bin (2.4.7-1ubuntu4.13) ...
==> default: Setting up apache2-data (2.4.7-1ubuntu4.13) ...
==> default: Setting up apache2 (2.4.7-1ubuntu4.13) ...
==> default: Enabling module mpm_event.
==> default: Enabling module authz_core.
==> default: Enabling module authz_host.
==> default: Enabling module authn_core.
==> default: Enabling module auth_basic.
==> default: Enabling module access_compat.
==> default: Enabling module authn_file.
==> default: Enabling module authz_user.
==> default: Enabling module alias.
==> default: Enabling module dir.
==> default: Enabling module autoindex.
==> default: Enabling module env.
==> default: Enabling module mime.
==> default: Enabling module negotiation.
==> default: Enabling module setenvif.
==> default: Enabling module filter.
==> default: Enabling module deflate.
==> default: Enabling module status.
==> default: Enabling conf charset.
==> default: Enabling conf localized-error-pages.
==> default: Enabling conf other-vhosts-access-log.
==> default: Enabling conf security.
==> default: Enabling conf serve-cgi-bin.
==> default: Enabling site 000-default.
==> default:  * Starting web server apache2
==> default:  * 
==> default: Setting up php-pear (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up pear-channels (0~20131124-1) ...
==> default: Setting up php-timer (1.0.5-1) ...
==> default: Setting up php-invoker (1.1.0-1) ...
==> default: Setting up php-symfony2-yaml (2.4.1-1) ...
==> default: Setting up php5-xdebug (2.2.3-2build1) ...
==> default: Setting up ssl-cert (1.0.33) ...
==> default: Processing triggers for ureadahead (0.100.0-16) ...
==> default: Processing triggers for ufw (0.34~rc-0ubuntu2) ...
==> default: Setting up libapache2-mod-php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Module mpm_event disabled.
==> default: Enabling module mpm_prefork.
==> default:  * Restarting web server apache2
==> default:    ...done.
==> default:  * Restarting web server apache2
==> default:    ...done.
==> default: Setting up php5 (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Setting up php-file-iterator (1.3.1-2) ...
==> default: Setting up php-token-stream (1.1.3-2) ...
==> default: Setting up php-text-template (1.1.1-2) ...
==> default: Setting up php-codecoverage (1.2.13+dfsg1-1) ...
==> default: Setting up phpunit-mock-object (1.2.3-1) ...
==> default: Setting up phpunit (3.7.28-1) ...
==> default: Setting up phpunit-story (1.0.0-3) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following NEW packages will be installed:
==> default:   apache2-dev aspell aspell-en autoconf automake autotools-dev bison
==> default:   build-essential chrpath comerr-dev debhelper dh-apparmor dictionaries-common
==> default:   dpkg-dev flex freetds-common freetds-dev g++ g++-4.8 gettext icu-devtools
==> default:   intltool-debian krb5-multidev language-pack-de language-pack-de-base libaio1
==> default:   libapr1-dev libaprutil1-dev libaspell-dev libaspell15 libbison-dev
==> default:   libbsd-dev libbz2-dev libcroco3 libct4 libcurl4-openssl-dev libdb-dev
==> default:   libdb5.3-dev libdbd-mysql-perl libdbi-perl libdpkg-perl libedit-dev libelfg0
==> default:   libenchant-dev libenchant1c2a libevent-core-2.0-5 libevent-dev
==> default:   libevent-extra-2.0-5 libevent-openssl-2.0-5 libevent-pthreads-2.0-5
==> default:   libexpat1-dev libfl-dev libfontconfig1-dev libfreetype6-dev libgcrypt11-dev
==> default:   libgd-dev libglib2.0-bin libglib2.0-dev libgmp-dev libgmp3-dev libgmpxx4ldbl
==> default:   libgnutls-dev libgnutlsxx27 libgpg-error-dev libgssrpc4 libhunspell-1.3-0
==> default:   libice-dev libicu-dev libidn11-dev libjbig-dev libjpeg-dev
==> default:   libjpeg-turbo8-dev libjpeg8-dev libkadm5clnt-mit9 libkadm5srv-mit9 libkdb5-7
==> default:   libkrb5-dev libldap2-dev libltdl-dev liblzma-dev libmagic-dev libmhash-dev
==> default:   libmhash2 libmysqlclient-dev libmysqlclient18 libodbc1 libp11-kit-dev
==> default:   libpam0g-dev libpcre3-dev libpcrecpp0 libperl5.18 libpng12-dev libpq-dev
==> default:   libpq5 libpspell-dev libpthread-stubs0-dev librecode-dev librecode0
==> default:   librtmp-dev libsasl2-dev libsctp-dev libsctp1 libsensors4 libsensors4-dev
==> default:   libsm-dev libsnmp-base libsnmp-dev libsnmp30 libsqlite3-dev libssl-dev
==> default:   libstdc++-4.8-dev libsybdb5 libsystemd-daemon-dev libtasn1-6-dev
==> default:   libterm-readkey-perl libtidy-0.99-0 libtidy-dev libtiff5-dev libtiffxx5
==> default:   libtinfo-dev libtool libunistring0 libvpx-dev libwrap0-dev libx11-dev
==> default:   libxau-dev libxcb1-dev libxdmcp-dev libxml2-dev libxmltok1 libxmltok1-dev
==> default:   libxpm-dev libxslt1-dev libxslt1.1 libxt-dev m4 mysql-client-5.5
==> default:   mysql-client-core-5.5 mysql-common mysql-server mysql-server-5.5
==> default:   mysql-server-core-5.5 odbcinst odbcinst1debian2 pkg-config po-debconf re2c
==> default:   systemtap-sdt-dev unixodbc unixodbc-dev uuid-dev x11proto-core-dev
==> default:   x11proto-input-dev x11proto-kb-dev xorg-sgml-doctools xtrans-dev zlib1g-dev
==> default: 0 upgraded, 157 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 68.8 MB of archives.
==> default: After this operation, 329 MB of additional disk space will be used.
==> default: Do you want to continue?
==> default:  [Y/n] 
==> default: Abort.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: curl is already the newest version.
==> default: libxml2 is already the newest version.
==> default: php-pear is already the newest version.
==> default: php-pear set to manually installed.
==> default: php5 is already the newest version.
==> default: php5 set to manually installed.
==> default: php5-cli is already the newest version.
==> default: php5-cli set to manually installed.
==> default: The following extra packages will be installed:
==> default:   autotools-dev debhelper dh-apparmor dpkg-dev g++ g++-4.8 gettext
==> default:   intltool-debian libalgorithm-diff-perl libalgorithm-diff-xs-perl
==> default:   libalgorithm-merge-perl libasprintf-dev libbison-dev libcroco3 libdpkg-perl
==> default:   libfile-fcntllock-perl libgettextpo-dev libgettextpo0 libltdl-dev
==> default:   libmail-sendmail-perl libreadline6-dev libssl-dev libssl-doc
==> default:   libstdc++-4.8-dev libsys-hostname-long-perl libtinfo-dev libtool
==> default:   libunistring0 libxslt1.1 m4 pkg-php-tools po-debconf shtool zlib1g-dev
==> default: Suggested packages:
==> default:   autoconf2.13 autoconf-archive gnu-standards autoconf-doc bison-doc dh-make
==> default:   apparmor-easyprof debian-keyring g++-multilib g++-4.8-multilib gcc-4.8-doc
==> default:   libstdc++6-4.8-dbg gettext-doc libtool-doc libstdc++-4.8-doc automaken
==> default:   gfortran fortran95-compiler gcj-jdk pkg-config libmail-box-perl
==> default: The following NEW packages will be installed:
==> default:   autoconf automake autotools-dev bison build-essential debhelper dh-apparmor
==> default:   dpkg-dev g++ g++-4.8 gettext intltool-debian libalgorithm-diff-perl
==> default:   libalgorithm-diff-xs-perl libalgorithm-merge-perl libasprintf-dev
==> default:   libbison-dev libbz2-dev libcroco3 libdpkg-perl libfile-fcntllock-perl
==> default:   libgettextpo-dev libgettextpo0 libltdl-dev libmail-sendmail-perl
==> default:   libreadline-dev libreadline6-dev libssl-dev libssl-doc libstdc++-4.8-dev
==> default:   libsys-hostname-long-perl libtinfo-dev libtool libunistring0 libxml2-dev
==> default:   libxslt1-dev libxslt1.1 m4 php5-dev pkg-php-tools po-debconf re2c shtool
==> default:   zlib1g-dev
==> default: 0 upgraded, 44 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 29.0 MB of archives.
==> default: After this operation, 80.4 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libcroco3 amd64 0.6.8-2ubuntu1 [82.4 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main libunistring0 amd64 0.9.3-5ubuntu3 [271 kB]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgettextpo0 amd64 0.18.3.1-1ubuntu3 [108 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty/main libxslt1.1 amd64 1.1.28-2build1 [145 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main m4 amd64 1.4.17-2ubuntu1 [195 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main autoconf all 2.69-6 [322 kB]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty/main autotools-dev all 20130810.1 [44.3 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty/main automake all 1:1.14.1-2ubuntu1 [510 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty/main libbison-dev amd64 2:3.0.2.dfsg-2 [338 kB]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty/main bison amd64 2:3.0.2.dfsg-2 [257 kB]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libstdc++-4.8-dev amd64 4.8.4-2ubuntu1~14.04.3 [1,053 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty-updates/main g++-4.8 amd64 4.8.4-2ubuntu1~14.04.3 [18.1 MB]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty/main g++ amd64 4:4.8.2-1ubuntu6 [1,490 B]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libdpkg-perl all 1.17.5ubuntu5.7 [179 kB]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty-updates/main dpkg-dev all 1.17.5ubuntu5.7 [726 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/main build-essential amd64 11.6ubuntu6 [4,838 B]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty-updates/main gettext amd64 0.18.3.1-1ubuntu3 [829 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/main intltool-debian all 0.35.0+20060710.1 [31.6 kB]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/main po-debconf all 1.0.16+nmu2ubuntu1 [210 kB]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty-updates/main dh-apparmor all 2.8.95~2430-0ubuntu5.3 [12.2 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/main debhelper all 9.20131227ubuntu1 [604 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-perl all 1.19.02-3 [50.0 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-xs-perl amd64 0.04-2build4 [12.6 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-merge-perl all 0.08-2 [12.7 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libasprintf-dev amd64 0.18.3.1-1ubuntu3 [4,438 B]
==> default: Get:26 http://archive.ubuntu.com/ubuntu/ trusty/main libbz2-dev amd64 1.0.6-5 [33.2 kB]
==> default: Get:27 http://archive.ubuntu.com/ubuntu/ trusty/main libfile-fcntllock-perl amd64 0.14-2build1 [15.9 kB]
==> default: Get:28 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgettextpo-dev amd64 0.18.3.1-1ubuntu3 [122 kB]
==> default: Get:29 http://archive.ubuntu.com/ubuntu/ trusty/main libltdl-dev amd64 2.4.2-1.7ubuntu1 [157 kB]
==> default: Get:30 http://archive.ubuntu.com/ubuntu/ trusty/main libsys-hostname-long-perl all 1.4-3 [11.3 kB]
==> default: Get:31 http://archive.ubuntu.com/ubuntu/ trusty/main libmail-sendmail-perl all 0.79.16-1 [26.5 kB]
==> default: Get:32 http://archive.ubuntu.com/ubuntu/ trusty/main libtinfo-dev amd64 5.9+20140118-1ubuntu1 [76.3 kB]
==> default: Get:33 http://archive.ubuntu.com/ubuntu/ trusty/main libreadline6-dev amd64 6.3-4ubuntu2 [213 kB]
==> default: Get:34 http://archive.ubuntu.com/ubuntu/ trusty/main libreadline-dev amd64 6.3-4ubuntu2 [988 B]
==> default: Get:35 http://archive.ubuntu.com/ubuntu/ trusty/main zlib1g-dev amd64 1:1.2.8.dfsg-1ubuntu1 [183 kB]
==> default: Get:36 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-dev amd64 1.0.1f-1ubuntu2.21 [1,074 kB]
==> default: Get:37 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libssl-doc all 1.0.1f-1ubuntu2.21 [971 kB]
==> default: Get:38 http://archive.ubuntu.com/ubuntu/ trusty/main libtool amd64 2.4.2-1.7ubuntu1 [188 kB]
==> default: Get:39 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libxml2-dev amd64 2.9.1+dfsg1-3ubuntu4.8 [631 kB]
==> default: Get:40 http://archive.ubuntu.com/ubuntu/ trusty/main libxslt1-dev amd64 1.1.28-2build1 [407 kB]
==> default: Get:41 http://archive.ubuntu.com/ubuntu/ trusty/main shtool all 2.0.8-6 [149 kB]
==> default: Get:42 http://archive.ubuntu.com/ubuntu/ trusty-updates/main php5-dev amd64 5.5.9+dfsg-1ubuntu4.20 [356 kB]
==> default: Get:43 http://archive.ubuntu.com/ubuntu/ trusty/main re2c amd64 0.13.5-1build2 [208 kB]
==> default: Get:44 http://archive.ubuntu.com/ubuntu/ trusty/main pkg-php-tools all 1.11 [21.6 kB]
==> default: Fetched 29.0 MB in 1min 2s (465 kB/s)
==> default: Selecting previously unselected package libcroco3:amd64.
==> default: (Reading database ... 65226 files and directories currently installed.)
==> default: Preparing to unpack .../libcroco3_0.6.8-2ubuntu1_amd64.deb ...
==> default: Unpacking libcroco3:amd64 (0.6.8-2ubuntu1) ...
==> default: Selecting previously unselected package libunistring0:amd64.
==> default: Preparing to unpack .../libunistring0_0.9.3-5ubuntu3_amd64.deb ...
==> default: Unpacking libunistring0:amd64 (0.9.3-5ubuntu3) ...
==> default: Selecting previously unselected package libgettextpo0:amd64.
==> default: Preparing to unpack .../libgettextpo0_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libgettextpo0:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libxslt1.1:amd64.
==> default: Preparing to unpack .../libxslt1.1_1.1.28-2build1_amd64.deb ...
==> default: Unpacking libxslt1.1:amd64 (1.1.28-2build1) ...
==> default: Selecting previously unselected package m4.
==> default: Preparing to unpack .../m4_1.4.17-2ubuntu1_amd64.deb ...
==> default: Unpacking m4 (1.4.17-2ubuntu1) ...
==> default: Selecting previously unselected package autoconf.
==> default: Preparing to unpack .../autoconf_2.69-6_all.deb ...
==> default: Unpacking autoconf (2.69-6) ...
==> default: Selecting previously unselected package autotools-dev.
==> default: Preparing to unpack .../autotools-dev_20130810.1_all.deb ...
==> default: Unpacking autotools-dev (20130810.1) ...
==> default: Selecting previously unselected package automake.
==> default: Preparing to unpack .../automake_1%3a1.14.1-2ubuntu1_all.deb ...
==> default: Unpacking automake (1:1.14.1-2ubuntu1) ...
==> default: Selecting previously unselected package libbison-dev:amd64.
==> default: Preparing to unpack .../libbison-dev_2%3a3.0.2.dfsg-2_amd64.deb ...
==> default: Unpacking libbison-dev:amd64 (2:3.0.2.dfsg-2) ...
==> default: Selecting previously unselected package bison.
==> default: Preparing to unpack .../bison_2%3a3.0.2.dfsg-2_amd64.deb ...
==> default: Unpacking bison (2:3.0.2.dfsg-2) ...
==> default: Selecting previously unselected package libstdc++-4.8-dev:amd64.
==> default: Preparing to unpack .../libstdc++-4.8-dev_4.8.4-2ubuntu1~14.04.3_amd64.deb ...
==> default: Unpacking libstdc++-4.8-dev:amd64 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Selecting previously unselected package g++-4.8.
==> default: Preparing to unpack .../g++-4.8_4.8.4-2ubuntu1~14.04.3_amd64.deb ...
==> default: Unpacking g++-4.8 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Selecting previously unselected package g++.
==> default: Preparing to unpack .../g++_4%3a4.8.2-1ubuntu6_amd64.deb ...
==> default: Unpacking g++ (4:4.8.2-1ubuntu6) ...
==> default: Selecting previously unselected package libdpkg-perl.
==> default: Preparing to unpack .../libdpkg-perl_1.17.5ubuntu5.7_all.deb ...
==> default: Unpacking libdpkg-perl (1.17.5ubuntu5.7) ...
==> default: Selecting previously unselected package dpkg-dev.
==> default: Preparing to unpack .../dpkg-dev_1.17.5ubuntu5.7_all.deb ...
==> default: Unpacking dpkg-dev (1.17.5ubuntu5.7) ...
==> default: Selecting previously unselected package build-essential.
==> default: Preparing to unpack .../build-essential_11.6ubuntu6_amd64.deb ...
==> default: Unpacking build-essential (11.6ubuntu6) ...
==> default: Selecting previously unselected package gettext.
==> default: Preparing to unpack .../gettext_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking gettext (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package intltool-debian.
==> default: Preparing to unpack .../intltool-debian_0.35.0+20060710.1_all.deb ...
==> default: Unpacking intltool-debian (0.35.0+20060710.1) ...
==> default: Selecting previously unselected package po-debconf.
==> default: Preparing to unpack .../po-debconf_1.0.16+nmu2ubuntu1_all.deb ...
==> default: Unpacking po-debconf (1.0.16+nmu2ubuntu1) ...
==> default: Selecting previously unselected package dh-apparmor.
==> default: Preparing to unpack .../dh-apparmor_2.8.95~2430-0ubuntu5.3_all.deb ...
==> default: Unpacking dh-apparmor (2.8.95~2430-0ubuntu5.3) ...
==> default: Selecting previously unselected package debhelper.
==> default: Preparing to unpack .../debhelper_9.20131227ubuntu1_all.deb ...
==> default: Unpacking debhelper (9.20131227ubuntu1) ...
==> default: Selecting previously unselected package libalgorithm-diff-perl.
==> default: Preparing to unpack .../libalgorithm-diff-perl_1.19.02-3_all.deb ...
==> default: Unpacking libalgorithm-diff-perl (1.19.02-3) ...
==> default: Selecting previously unselected package libalgorithm-diff-xs-perl.
==> default: Preparing to unpack .../libalgorithm-diff-xs-perl_0.04-2build4_amd64.deb ...
==> default: Unpacking libalgorithm-diff-xs-perl (0.04-2build4) ...
==> default: Selecting previously unselected package libalgorithm-merge-perl.
==> default: Preparing to unpack .../libalgorithm-merge-perl_0.08-2_all.deb ...
==> default: Unpacking libalgorithm-merge-perl (0.08-2) ...
==> default: Selecting previously unselected package libasprintf-dev:amd64.
==> default: Preparing to unpack .../libasprintf-dev_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libasprintf-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libbz2-dev:amd64.
==> default: Preparing to unpack .../libbz2-dev_1.0.6-5_amd64.deb ...
==> default: Unpacking libbz2-dev:amd64 (1.0.6-5) ...
==> default: Selecting previously unselected package libfile-fcntllock-perl.
==> default: Preparing to unpack .../libfile-fcntllock-perl_0.14-2build1_amd64.deb ...
==> default: Unpacking libfile-fcntllock-perl (0.14-2build1) ...
==> default: Selecting previously unselected package libgettextpo-dev:amd64.
==> default: Preparing to unpack .../libgettextpo-dev_0.18.3.1-1ubuntu3_amd64.deb ...
==> default: Unpacking libgettextpo-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Selecting previously unselected package libltdl-dev:amd64.
==> default: Preparing to unpack .../libltdl-dev_2.4.2-1.7ubuntu1_amd64.deb ...
==> default: Unpacking libltdl-dev:amd64 (2.4.2-1.7ubuntu1) ...
==> default: Selecting previously unselected package libsys-hostname-long-perl.
==> default: Preparing to unpack .../libsys-hostname-long-perl_1.4-3_all.deb ...
==> default: Unpacking libsys-hostname-long-perl (1.4-3) ...
==> default: Selecting previously unselected package libmail-sendmail-perl.
==> default: Preparing to unpack .../libmail-sendmail-perl_0.79.16-1_all.deb ...
==> default: Unpacking libmail-sendmail-perl (0.79.16-1) ...
==> default: Selecting previously unselected package libtinfo-dev:amd64.
==> default: Preparing to unpack .../libtinfo-dev_5.9+20140118-1ubuntu1_amd64.deb ...
==> default: Unpacking libtinfo-dev:amd64 (5.9+20140118-1ubuntu1) ...
==> default: Selecting previously unselected package libreadline6-dev:amd64.
==> default: Preparing to unpack .../libreadline6-dev_6.3-4ubuntu2_amd64.deb ...
==> default: Unpacking libreadline6-dev:amd64 (6.3-4ubuntu2) ...
==> default: Selecting previously unselected package libreadline-dev:amd64.
==> default: Preparing to unpack .../libreadline-dev_6.3-4ubuntu2_amd64.deb ...
==> default: Unpacking libreadline-dev:amd64 (6.3-4ubuntu2) ...
==> default: Selecting previously unselected package zlib1g-dev:amd64.
==> default: Preparing to unpack .../zlib1g-dev_1%3a1.2.8.dfsg-1ubuntu1_amd64.deb ...
==> default: Unpacking zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...
==> default: Selecting previously unselected package libssl-dev:amd64.
==> default: Preparing to unpack .../libssl-dev_1.0.1f-1ubuntu2.21_amd64.deb ...
==> default: Unpacking libssl-dev:amd64 (1.0.1f-1ubuntu2.21) ...
==> default: Selecting previously unselected package libssl-doc.
==> default: Preparing to unpack .../libssl-doc_1.0.1f-1ubuntu2.21_all.deb ...
==> default: Unpacking libssl-doc (1.0.1f-1ubuntu2.21) ...
==> default: Selecting previously unselected package libtool.
==> default: Preparing to unpack .../libtool_2.4.2-1.7ubuntu1_amd64.deb ...
==> default: Unpacking libtool (2.4.2-1.7ubuntu1) ...
==> default: Selecting previously unselected package libxml2-dev:amd64.
==> default: Preparing to unpack .../libxml2-dev_2.9.1+dfsg1-3ubuntu4.8_amd64.deb ...
==> default: Unpacking libxml2-dev:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...
==> default: Selecting previously unselected package libxslt1-dev:amd64.
==> default: Preparing to unpack .../libxslt1-dev_1.1.28-2build1_amd64.deb ...
==> default: Unpacking libxslt1-dev:amd64 (1.1.28-2build1) ...
==> default: Selecting previously unselected package shtool.
==> default: Preparing to unpack .../shtool_2.0.8-6_all.deb ...
==> default: Unpacking shtool (2.0.8-6) ...
==> default: Selecting previously unselected package php5-dev.
==> default: Preparing to unpack .../php5-dev_5.5.9+dfsg-1ubuntu4.20_amd64.deb ...
==> default: Unpacking php5-dev (5.5.9+dfsg-1ubuntu4.20) ...
==> default: Selecting previously unselected package re2c.
==> default: Preparing to unpack .../re2c_0.13.5-1build2_amd64.deb ...
==> default: Unpacking re2c (0.13.5-1build2) ...
==> default: Selecting previously unselected package pkg-php-tools.
==> default: Preparing to unpack .../pkg-php-tools_1.11_all.deb ...
==> default: Unpacking pkg-php-tools (1.11) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Processing triggers for install-info (5.2.0.dfsg.1-2) ...
==> default: Setting up libcroco3:amd64 (0.6.8-2ubuntu1) ...
==> default: Setting up libunistring0:amd64 (0.9.3-5ubuntu3) ...
==> default: Setting up libgettextpo0:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libxslt1.1:amd64 (1.1.28-2build1) ...
==> default: Setting up m4 (1.4.17-2ubuntu1) ...
==> default: Setting up autoconf (2.69-6) ...
==> default: Setting up autotools-dev (20130810.1) ...
==> default: Setting up automake (1:1.14.1-2ubuntu1) ...
==> default: update-alternatives: 
==> default: using /usr/bin/automake-1.14 to provide /usr/bin/automake (automake) in auto mode
==> default: Setting up libbison-dev:amd64 (2:3.0.2.dfsg-2) ...
==> default: Setting up bison (2:3.0.2.dfsg-2) ...
==> default: update-alternatives: 
==> default: using /usr/bin/bison.yacc to provide /usr/bin/yacc (yacc) in auto mode
==> default: Setting up libstdc++-4.8-dev:amd64 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Setting up g++-4.8 (4.8.4-2ubuntu1~14.04.3) ...
==> default: Setting up g++ (4:4.8.2-1ubuntu6) ...
==> default: update-alternatives: 
==> default: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
==> default: Setting up libdpkg-perl (1.17.5ubuntu5.7) ...
==> default: Setting up dpkg-dev (1.17.5ubuntu5.7) ...
==> default: Setting up build-essential (11.6ubuntu6) ...
==> default: Setting up gettext (0.18.3.1-1ubuntu3) ...
==> default: Setting up intltool-debian (0.35.0+20060710.1) ...
==> default: Setting up po-debconf (1.0.16+nmu2ubuntu1) ...
==> default: Setting up dh-apparmor (2.8.95~2430-0ubuntu5.3) ...
==> default: Setting up debhelper (9.20131227ubuntu1) ...
==> default: Setting up libalgorithm-diff-perl (1.19.02-3) ...
==> default: Setting up libalgorithm-diff-xs-perl (0.04-2build4) ...
==> default: Setting up libalgorithm-merge-perl (0.08-2) ...
==> default: Setting up libasprintf-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libbz2-dev:amd64 (1.0.6-5) ...
==> default: Setting up libfile-fcntllock-perl (0.14-2build1) ...
==> default: Setting up libgettextpo-dev:amd64 (0.18.3.1-1ubuntu3) ...
==> default: Setting up libltdl-dev:amd64 (2.4.2-1.7ubuntu1) ...
==> default: Setting up libsys-hostname-long-perl (1.4-3) ...
==> default: Setting up libmail-sendmail-perl (0.79.16-1) ...
==> default: Setting up libtinfo-dev:amd64 (5.9+20140118-1ubuntu1) ...
==> default: Setting up libreadline6-dev:amd64 (6.3-4ubuntu2) ...
==> default: Setting up libreadline-dev:amd64 (6.3-4ubuntu2) ...
==> default: Setting up zlib1g-dev:amd64 (1:1.2.8.dfsg-1ubuntu1) ...
==> default: Setting up libssl-dev:amd64 (1.0.1f-1ubuntu2.21) ...
==> default: Setting up libssl-doc (1.0.1f-1ubuntu2.21) ...
==> default: Setting up libtool (2.4.2-1.7ubuntu1) ...
==> default: Setting up libxml2-dev:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...
==> default: Setting up libxslt1-dev:amd64 (1.1.28-2build1) ...
==> default: Setting up shtool (2.0.8-6) ...
==> default: Setting up php5-dev (5.5.9+dfsg-1ubuntu4.20) ...
==> default: update-alternatives: 
==> default: using /usr/bin/php-config5 to provide /usr/bin/php-config (php-config) in auto mode
==> default: update-alternatives: 
==> default: using /usr/bin/phpize5 to provide /usr/bin/phpize (phpize) in auto mode
==> default: Setting up re2c (0.13.5-1build2) ...
==> default: Setting up pkg-php-tools (1.11) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libjpeg8 is already the newest version.
==> default: libjpeg8 set to manually installed.
==> default: libltdl-dev is already the newest version.
==> default: libltdl-dev set to manually installed.
==> default: libltdl7 is already the newest version.
==> default: libltdl7 set to manually installed.
==> default: libxpm4 is already the newest version.
==> default: libxpm4 set to manually installed.
==> default: libfreetype6 is already the newest version.
==> default: libfreetype6 set to manually installed.
==> default: libgd3 is already the newest version.
==> default: libgd3 set to manually installed.
==> default: libpng12-0 is already the newest version.
==> default: The following extra packages will be installed:
==> default:   libexpat1-dev libfontconfig1-dev libice-dev libjbig-dev libjpeg-turbo8-dev
==> default:   liblzma-dev libpthread-stubs0-dev libsm-dev libtiff5-dev libtiffxx5
==> default:   libvpx-dev libx11-dev libx11-doc libxau-dev libxcb1-dev libxdmcp-dev
==> default:   libxpm-dev libxt-dev pkg-config x11proto-core-dev x11proto-input-dev
==> default:   x11proto-kb-dev xorg-sgml-doctools xtrans-dev
==> default: Suggested packages:
==> default:   libice-doc liblzma-doc libsm-doc libxcb-doc libxt-doc
==> default: The following NEW packages will be installed:
==> default:   libexpat1-dev libfontconfig1-dev libfreetype6-dev libgd-dev libice-dev
==> default:   libjbig-dev libjpeg-dev libjpeg-turbo8-dev libjpeg8-dev liblzma-dev
==> default:   libpng12-dev libpthread-stubs0-dev libsm-dev libtiff5-dev libtiffxx5
==> default:   libvpx-dev libx11-dev libx11-doc libxau-dev libxcb1-dev libxdmcp-dev
==> default:   libxpm-dev libxt-dev pkg-config x11proto-core-dev x11proto-input-dev
==> default:   x11proto-kb-dev xorg-sgml-doctools xtrans-dev
==> default: 0 upgraded, 29 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 7,204 kB of archives.
==> default: After this operation, 32.6 MB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libtiffxx5 amd64 4.0.3-7ubuntu0.4 [5,634 B]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libjbig-dev amd64 2.0-2ubuntu4.1 [6,268 B]
==> default: Get:3 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libexpat1-dev amd64 2.1.0-4ubuntu1.3 [115 kB]
==> default: Get:4 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libpng12-dev amd64 1.2.50-1ubuntu2.14.04.2 [206 kB]
==> default: Get:5 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libfreetype6-dev amd64 2.5.2-1ubuntu2.5 [621 kB]
==> default: Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main pkg-config amd64 0.26-1ubuntu4 [40.9 kB]
==> default: Get:7 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libfontconfig1-dev amd64 2.11.0-0ubuntu4.2 [665 kB]
==> default: Get:8 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg-turbo8-dev amd64 1.3.0-0ubuntu2 [242 kB]
==> default: Get:9 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg8-dev amd64 8c-2ubuntu8 [1,552 B]
==> default: Get:10 http://archive.ubuntu.com/ubuntu/ trusty/main libjpeg-dev amd64 8c-2ubuntu8 [1,546 B]
==> default: Get:11 http://archive.ubuntu.com/ubuntu/ trusty/main xorg-sgml-doctools all 1:1.11-1 [12.9 kB]
==> default: Get:12 http://archive.ubuntu.com/ubuntu/ trusty-updates/main x11proto-core-dev all 7.0.26-1~ubuntu2 [700 kB]
==> default: Get:13 http://archive.ubuntu.com/ubuntu/ trusty/main libxau-dev amd64 1:1.0.8-1 [11.1 kB]
==> default: Get:14 http://archive.ubuntu.com/ubuntu/ trusty/main libxdmcp-dev amd64 1:1.1.1-1 [26.9 kB]
==> default: Get:15 http://archive.ubuntu.com/ubuntu/ trusty/main x11proto-input-dev all 2.3-1 [139 kB]
==> default: Get:16 http://archive.ubuntu.com/ubuntu/ trusty/main x11proto-kb-dev all 1.0.6-2 [269 kB]
==> default: Get:17 http://archive.ubuntu.com/ubuntu/ trusty-updates/main xtrans-dev all 1.3.5-1~ubuntu14.04.1 [70.3 kB]
==> default: Get:18 http://archive.ubuntu.com/ubuntu/ trusty/main libpthread-stubs0-dev amd64 0.3-4 [4,068 B]
==> default: Get:19 http://archive.ubuntu.com/ubuntu/ trusty/main libxcb1-dev amd64 1.10-2ubuntu1 [76.6 kB]
==> default: Get:20 http://archive.ubuntu.com/ubuntu/ trusty/main libx11-dev amd64 2:1.6.2-1ubuntu2 [629 kB]
==> default: Get:21 http://archive.ubuntu.com/ubuntu/ trusty/main libxpm-dev amd64 1:3.5.10-1 [94.2 kB]
==> default: Get:22 http://archive.ubuntu.com/ubuntu/ trusty/main libice-dev amd64 2:1.0.8-2 [57.6 kB]
==> default: Get:23 http://archive.ubuntu.com/ubuntu/ trusty/main libsm-dev amd64 2:1.2.1-2 [19.9 kB]
==> default: Get:24 http://archive.ubuntu.com/ubuntu/ trusty/main libxt-dev amd64 1:1.1.4-1 [455 kB]
==> default: Get:25 http://archive.ubuntu.com/ubuntu/ trusty/main libvpx-dev amd64 1.3.0-2 [635 kB]
==> default: Get:26 http://archive.ubuntu.com/ubuntu/ trusty/main liblzma-dev amd64 5.1.1alpha+20120614-2ubuntu2 [137 kB]
==> default: Get:27 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libtiff5-dev amd64 4.0.3-7ubuntu0.4 [263 kB]
==> default: Get:28 http://archive.ubuntu.com/ubuntu/ trusty-updates/main libgd-dev amd64 2.1.0-3ubuntu0.5 [250 kB]
==> default: Get:29 http://archive.ubuntu.com/ubuntu/ trusty/main libx11-doc all 2:1.6.2-1ubuntu2 [1,448 kB]
==> default: Fetched 7,204 kB in 5s (1,308 kB/s)
==> default: Selecting previously unselected package libtiffxx5:amd64.
==> default: (Reading database ... 69684 files and directories currently installed.)
==> default: Preparing to unpack .../libtiffxx5_4.0.3-7ubuntu0.4_amd64.deb ...
==> default: Unpacking libtiffxx5:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Selecting previously unselected package libjbig-dev:amd64.
==> default: Preparing to unpack .../libjbig-dev_2.0-2ubuntu4.1_amd64.deb ...
==> default: Unpacking libjbig-dev:amd64 (2.0-2ubuntu4.1) ...
==> default: Selecting previously unselected package libexpat1-dev:amd64.
==> default: Preparing to unpack .../libexpat1-dev_2.1.0-4ubuntu1.3_amd64.deb ...
==> default: Unpacking libexpat1-dev:amd64 (2.1.0-4ubuntu1.3) ...
==> default: Selecting previously unselected package libpng12-dev.
==> default: Preparing to unpack .../libpng12-dev_1.2.50-1ubuntu2.14.04.2_amd64.deb ...
==> default: Unpacking libpng12-dev (1.2.50-1ubuntu2.14.04.2) ...
==> default: Selecting previously unselected package libfreetype6-dev.
==> default: Preparing to unpack .../libfreetype6-dev_2.5.2-1ubuntu2.5_amd64.deb ...
==> default: Unpacking libfreetype6-dev (2.5.2-1ubuntu2.5) ...
==> default: Selecting previously unselected package pkg-config.
==> default: Preparing to unpack .../pkg-config_0.26-1ubuntu4_amd64.deb ...
==> default: Unpacking pkg-config (0.26-1ubuntu4) ...
==> default: Selecting previously unselected package libfontconfig1-dev.
==> default: Preparing to unpack .../libfontconfig1-dev_2.11.0-0ubuntu4.2_amd64.deb ...
==> default: Unpacking libfontconfig1-dev (2.11.0-0ubuntu4.2) ...
==> default: Selecting previously unselected package libjpeg-turbo8-dev:amd64.
==> default: Preparing to unpack .../libjpeg-turbo8-dev_1.3.0-0ubuntu2_amd64.deb ...
==> default: Unpacking libjpeg-turbo8-dev:amd64 (1.3.0-0ubuntu2) ...
==> default: Selecting previously unselected package libjpeg8-dev:amd64.
==> default: Preparing to unpack .../libjpeg8-dev_8c-2ubuntu8_amd64.deb ...
==> default: Unpacking libjpeg8-dev:amd64 (8c-2ubuntu8) ...
==> default: Selecting previously unselected package libjpeg-dev:amd64.
==> default: Preparing to unpack .../libjpeg-dev_8c-2ubuntu8_amd64.deb ...
==> default: Unpacking libjpeg-dev:amd64 (8c-2ubuntu8) ...
==> default: Selecting previously unselected package xorg-sgml-doctools.
==> default: Preparing to unpack .../xorg-sgml-doctools_1%3a1.11-1_all.deb ...
==> default: Unpacking xorg-sgml-doctools (1:1.11-1) ...
==> default: Selecting previously unselected package x11proto-core-dev.
==> default: Preparing to unpack .../x11proto-core-dev_7.0.26-1~ubuntu2_all.deb ...
==> default: Unpacking x11proto-core-dev (7.0.26-1~ubuntu2) ...
==> default: Selecting previously unselected package libxau-dev:amd64.
==> default: Preparing to unpack .../libxau-dev_1%3a1.0.8-1_amd64.deb ...
==> default: Unpacking libxau-dev:amd64 (1:1.0.8-1) ...
==> default: Selecting previously unselected package libxdmcp-dev:amd64.
==> default: Preparing to unpack .../libxdmcp-dev_1%3a1.1.1-1_amd64.deb ...
==> default: Unpacking libxdmcp-dev:amd64 (1:1.1.1-1) ...
==> default: Selecting previously unselected package x11proto-input-dev.
==> default: Preparing to unpack .../x11proto-input-dev_2.3-1_all.deb ...
==> default: Unpacking x11proto-input-dev (2.3-1) ...
==> default: Selecting previously unselected package x11proto-kb-dev.
==> default: Preparing to unpack .../x11proto-kb-dev_1.0.6-2_all.deb ...
==> default: Unpacking x11proto-kb-dev (1.0.6-2) ...
==> default: Selecting previously unselected package xtrans-dev.
==> default: Preparing to unpack .../xtrans-dev_1.3.5-1~ubuntu14.04.1_all.deb ...
==> default: Unpacking xtrans-dev (1.3.5-1~ubuntu14.04.1) ...
==> default: Selecting previously unselected package libpthread-stubs0-dev:amd64.
==> default: Preparing to unpack .../libpthread-stubs0-dev_0.3-4_amd64.deb ...
==> default: Unpacking libpthread-stubs0-dev:amd64 (0.3-4) ...
==> default: Selecting previously unselected package libxcb1-dev:amd64.
==> default: Preparing to unpack .../libxcb1-dev_1.10-2ubuntu1_amd64.deb ...
==> default: Unpacking libxcb1-dev:amd64 (1.10-2ubuntu1) ...
==> default: Selecting previously unselected package libx11-dev:amd64.
==> default: Preparing to unpack .../libx11-dev_2%3a1.6.2-1ubuntu2_amd64.deb ...
==> default: Unpacking libx11-dev:amd64 (2:1.6.2-1ubuntu2) ...
==> default: Selecting previously unselected package libxpm-dev:amd64.
==> default: Preparing to unpack .../libxpm-dev_1%3a3.5.10-1_amd64.deb ...
==> default: Unpacking libxpm-dev:amd64 (1:3.5.10-1) ...
==> default: Selecting previously unselected package libice-dev:amd64.
==> default: Preparing to unpack .../libice-dev_2%3a1.0.8-2_amd64.deb ...
==> default: Unpacking libice-dev:amd64 (2:1.0.8-2) ...
==> default: Selecting previously unselected package libsm-dev:amd64.
==> default: Preparing to unpack .../libsm-dev_2%3a1.2.1-2_amd64.deb ...
==> default: Unpacking libsm-dev:amd64 (2:1.2.1-2) ...
==> default: Selecting previously unselected package libxt-dev:amd64.
==> default: Preparing to unpack .../libxt-dev_1%3a1.1.4-1_amd64.deb ...
==> default: Unpacking libxt-dev:amd64 (1:1.1.4-1) ...
==> default: Selecting previously unselected package libvpx-dev:amd64.
==> default: Preparing to unpack .../libvpx-dev_1.3.0-2_amd64.deb ...
==> default: Unpacking libvpx-dev:amd64 (1.3.0-2) ...
==> default: Selecting previously unselected package liblzma-dev:amd64.
==> default: Preparing to unpack .../liblzma-dev_5.1.1alpha+20120614-2ubuntu2_amd64.deb ...
==> default: Unpacking liblzma-dev:amd64 (5.1.1alpha+20120614-2ubuntu2) ...
==> default: Selecting previously unselected package libtiff5-dev:amd64.
==> default: Preparing to unpack .../libtiff5-dev_4.0.3-7ubuntu0.4_amd64.deb ...
==> default: Unpacking libtiff5-dev:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Selecting previously unselected package libgd-dev:amd64.
==> default: Preparing to unpack .../libgd-dev_2.1.0-3ubuntu0.5_amd64.deb ...
==> default: Unpacking libgd-dev:amd64 (2.1.0-3ubuntu0.5) ...
==> default: Selecting previously unselected package libx11-doc.
==> default: Preparing to unpack .../libx11-doc_2%3a1.6.2-1ubuntu2_all.deb ...
==> default: Unpacking libx11-doc (2:1.6.2-1ubuntu2) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libtiffxx5:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Setting up libjbig-dev:amd64 (2.0-2ubuntu4.1) ...
==> default: Setting up libexpat1-dev:amd64 (2.1.0-4ubuntu1.3) ...
==> default: Setting up libpng12-dev (1.2.50-1ubuntu2.14.04.2) ...
==> default: Setting up libfreetype6-dev (2.5.2-1ubuntu2.5) ...
==> default: Setting up pkg-config (0.26-1ubuntu4) ...
==> default: Setting up libfontconfig1-dev (2.11.0-0ubuntu4.2) ...
==> default: Setting up libjpeg-turbo8-dev:amd64 (1.3.0-0ubuntu2) ...
==> default: Setting up libjpeg8-dev:amd64 (8c-2ubuntu8) ...
==> default: Setting up libjpeg-dev:amd64 (8c-2ubuntu8) ...
==> default: Setting up xorg-sgml-doctools (1:1.11-1) ...
==> default: Setting up x11proto-core-dev (7.0.26-1~ubuntu2) ...
==> default: Setting up libxau-dev:amd64 (1:1.0.8-1) ...
==> default: Setting up libxdmcp-dev:amd64 (1:1.1.1-1) ...
==> default: Setting up x11proto-input-dev (2.3-1) ...
==> default: Setting up x11proto-kb-dev (1.0.6-2) ...
==> default: Setting up xtrans-dev (1.3.5-1~ubuntu14.04.1) ...
==> default: Setting up libpthread-stubs0-dev:amd64 (0.3-4) ...
==> default: Setting up libxcb1-dev:amd64 (1.10-2ubuntu1) ...
==> default: Setting up libx11-dev:amd64 (2:1.6.2-1ubuntu2) ...
==> default: Setting up libxpm-dev:amd64 (1:3.5.10-1) ...
==> default: Setting up libice-dev:amd64 (2:1.0.8-2) ...
==> default: Setting up libsm-dev:amd64 (2:1.2.1-2) ...
==> default: Setting up libxt-dev:amd64 (1:1.1.4-1) ...
==> default: Setting up libvpx-dev:amd64 (1.3.0-2) ...
==> default: Setting up liblzma-dev:amd64 (5.1.1alpha+20120614-2ubuntu2) ...
==> default: Setting up libtiff5-dev:amd64 (4.0.3-7ubuntu0.4) ...
==> default: Setting up libgd-dev:amd64 (2.1.0-3ubuntu0.5) ...
==> default: Setting up libx11-doc (2:1.6.2-1ubuntu2) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libssl-dev is already the newest version.
==> default: libssl-dev set to manually installed.
==> default: openssl is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: gettext is already the newest version.
==> default: gettext set to manually installed.
==> default: libgettextpo-dev is already the newest version.
==> default: libgettextpo-dev set to manually installed.
==> default: libgettextpo0 is already the newest version.
==> default: libgettextpo0 set to manually installed.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: php5-cli is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   libmcrypt4
==> default: Suggested packages:
==> default:   mcrypt
==> default: The following NEW packages will be installed:
==> default:   libmcrypt-dev libmcrypt4
==> default: 0 upgraded, 2 newly installed, 0 to remove and 15 not upgraded.
==> default: Need to get 145 kB of archives.
==> default: After this operation, 655 kB of additional disk space will be used.
==> default: Get:1 http://archive.ubuntu.com/ubuntu/ trusty/universe libmcrypt4 amd64 2.5.8-3.1ubuntu1 [61.9 kB]
==> default: Get:2 http://archive.ubuntu.com/ubuntu/ trusty/universe libmcrypt-dev amd64 2.5.8-3.1ubuntu1 [83.1 kB]
==> default: Fetched 145 kB in 2s (57.0 kB/s)
==> default: Selecting previously unselected package libmcrypt4.
==> default: (Reading database ... 71933 files and directories currently installed.)
==> default: Preparing to unpack .../libmcrypt4_2.5.8-3.1ubuntu1_amd64.deb ...
==> default: Unpacking libmcrypt4 (2.5.8-3.1ubuntu1) ...
==> default: Selecting previously unselected package libmcrypt-dev.
==> default: Preparing to unpack .../libmcrypt-dev_2.5.8-3.1ubuntu1_amd64.deb ...
==> default: Unpacking libmcrypt-dev (2.5.8-3.1ubuntu1) ...
==> default: Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
==> default: Setting up libmcrypt4 (2.5.8-3.1ubuntu1) ...
==> default: Setting up libmcrypt-dev (2.5.8-3.1ubuntu1) ...
==> default: Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: libreadline-dev is already the newest version.
==> default: 0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.
==> default: Running provisioner: shell...
    default: Running: /var/folders/gk/qkjjk8zs32v4jrg3k3xgf7h5y_y_66/T/vagrant-shell20170117-60197-3kzl9j.sh
==> default: install phpbrew and php54
==> default: # WARNING: curl extension might be required for fetching data.
==> default: Using root: /home/vagrant/.phpbrew
==> default: Initialization successfully finished!
==> default: <=====================================================>
==> default: Phpbrew environment is initialized, required directories are created under
==> default: 
==> default:     /home/vagrant/.phpbrew
==> default: 
==> default: Paste the following line(s) to the end of your ~/.bashrc and start a
==> default: new shell, phpbrew should be up and fully functional from there:
==> default: 
==> default:     source /home/vagrant/.phpbrew/bashrc
==> default: 
==> default: To enable PHP version info in your shell prompt, please set PHPBREW_SET_PROMPT=1
==> default: in your `~/.bashrc` before you source `~/.phpbrew/bashrc`
==> default: 
==> default:     export PHPBREW_SET_PROMPT=1
==> default: 
==> default: To enable .phpbrewrc file searching, please export the following variable:
==> default: 
==> default:     export PHPBREW_RC_ENABLE=1
==> default: 
==> default: 
==> default: For further instructions, simply run `phpbrew` to see the help message.
==> default: 
==> default: Enjoy phpbrew at $HOME!!
==> default: <=====================================================>
==> default: # WARNING: curl extension might be required for fetching data.
==> default: ===> Fetching release list...
==> default: Downloading https://secure.php.net/releases/index.php?json&version=7&max=100 via php stream
==> default: Downloading https://secure.php.net/releases/index.php?json&version=5&max=100 via php stream
==> default: 7.1: 7.1.0 ...
==> default: 7.0: 7.0.14, 7.0.13, 7.0.12, 7.0.11, 7.0.10, 7.0.9, 7.0.8, 7.0.7 ...
==> default: 5.6: 5.6.29, 5.6.28, 5.6.27, 5.6.26, 5.6.25, 5.6.24, 5.6.23, 5.6.22 ...
==> default: 5.5: 5.5.38, 5.5.37, 5.5.36, 5.5.35, 5.5.34, 5.5.33, 5.5.32, 5.5.31 ...
==> default: 5.4: 5.4.45, 5.4.44, 5.4.43, 5.4.42, 5.4.41, 5.4.40, 5.4.39, 5.4.38 ...
==> default: # WARNING: curl extension might be required for fetching data.
==> default: ===> Fetching release list...
==> default: Downloading https://secure.php.net/releases/index.php?json&version=7&max=100 via php stream
==> default: Downloading https://secure.php.net/releases/index.php?json&version=5&max=100 via php stream
==> default: 7.1: 1 releases
==> default: 7.0: 15 releases
==> default: 5.6: 30 releases
==> default: 5.5: 39 releases
==> default: 5.4: 31 releases
==> default: ===> Done
==> default: # WARNING: curl extension might be required for fetching data.
==> default: ===> phpbrew will now build 5.4.34
==> default: ===> Loading and resolving variants...
==> default: Downloading http://www.php.net/get/php-5.4.34.tar.bz2/from/this/mirror via php stream
==> default: ===> Extracting /home/vagrant/.phpbrew/distfiles/php-5.4.34.tar.bz2 to /home/vagrant/.phpbrew/build/tmp.1484670432/php-5.4.34
==> default: ===> Moving /home/vagrant/.phpbrew/build/tmp.1484670432/php-5.4.34 to /home/vagrant/.phpbrew/build/php-5.4.34
==> default: ===> Checking patches...
==> default: Checking patch for replace apache php module name with custom version name
==> default: ===> Configuring 5.4.34...
==> default: 
==> default: Use tail command to see what's going on:
==> default:    $ tail -F /home/vagrant/.phpbrew/build/php-5.4.34/build.log
==> default: ===> Checking patches...
==> default: Checking patch for php5.3.29 multi-sapi patch.
==> default: Checking patch for php5.3.x on 64bit machine when intl is enabled.
==> default: Checking patch for openssl dso linking patch
==> default: ===> Building...
==> default: Build finished: 2.9 minutes.
==> default: Installing...
==> default: ---> Creating php-fpm.conf
==> default: ---> Creating php.ini
==> default: ---> Copying /home/vagrant/.phpbrew/build/php-5.4.34/php.ini-development 
==> default: ---> Found date.timezone is not set, patching...
==> default: Congratulations! Now you have PHP with 5.4.34 as php-5.4.34
==> default: 
==> default: * To configure your installed PHP further, you can edit the config file at
==> default:     /home/vagrant/.phpbrew/php/php-5.4.34/etc/php.ini
==> default: 
==> default: * WARNING:
==> default:   You haven't setup your .bashrc file to load phpbrew shell script yet!
==> default:   Please run 'phpbrew init' to see the steps!
==> default: 
==> default: To use the newly built PHP, try the line(s) below:
==> default: 
==> default:     $ phpbrew use php-5.4.34
==> default: 
==> default: Or you can use switch command to switch your default php to php-5.4.34:
==> default: 
==> default:     $ phpbrew switch php-5.4.34
==> default: 
==> default: Enjoy!
==> default: switch php54
==> default: install php54-apc
==> default: # WARNING: curl extension might be required for fetching data.
==> default: PHP Notice:  Use of undefined constant CURLOPT_HEADER - assumed 'CURLOPT_HEADER' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: 
==> default: Notice: Use of undefined constant CURLOPT_HEADER - assumed 'CURLOPT_HEADER' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: PHP Notice:  Use of undefined constant CURLOPT_RETURNTRANSFER - assumed 'CURLOPT_RETURNTRANSFER' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: 
==> default: Notice: Use of undefined constant CURLOPT_RETURNTRANSFER - assumed 'CURLOPT_RETURNTRANSFER' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: PHP Notice:  Use of undefined constant CURLOPT_FORBID_REUSE - assumed 'CURLOPT_FORBID_REUSE' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: 
==> default: Notice: Use of undefined constant CURLOPT_FORBID_REUSE - assumed 'CURLOPT_FORBID_REUSE' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: PHP Notice:  Use of undefined constant CURLOPT_NOPROGRESS - assumed 'CURLOPT_NOPROGRESS' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: 
==> default: Notice: Use of undefined constant CURLOPT_NOPROGRESS - assumed 'CURLOPT_NOPROGRESS' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: PHP Notice:  Use of undefined constant CURLOPT_FAILONERROR - assumed 'CURLOPT_FAILONERROR' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: 
==> default: Notice: Use of undefined constant CURLOPT_FAILONERROR - assumed 'CURLOPT_FAILONERROR' in phar:///usr/bin/phpbrew/src/PhpBrew/Extension/Provider/PeclProvider.php on line 41
==> default: Downloading https://pecl.php.net/rest/r/apc/stable.txt via php stream
==> default: Downloading https://pecl.php.net/rest/r/apc/3.1.13.xml via php stream
==> default: Downloading https://pecl.php.net/rest/r/apc/stable.txt via php stream
==> default: Downloading https://pecl.php.net/rest/r/apc/3.1.13.xml via php stream
==> default: Downloading http://pecl.php.net/get/APC-3.1.13.tgz via php stream
==> default: ===> Extracting to /home/vagrant/.phpbrew/build/php-5.4.34/ext...
==> default: ===> Installing apc extension...
==> default: Log stored at: /home/vagrant/.phpbrew/build/php-5.4.34/ext/apc/build.log
==> default: Changing directory to /home/vagrant/.phpbrew/build/php-5.4.34/ext/apc
==> default: ===> Phpize...
==> default: ===> Configuring...
==> default: ===> Building...
==> default: ===> Running make all: /usr/bin/make -C '/home/vagrant/.phpbrew/build/php-5.4.34/ext/apc' 'all'  >> '/home/vagrant/.phpbrew/build/php-5.4.34/ext/apc/build.log' 2>&1
==> default: ===> Installing...
==> default: ===> Running make install: /usr/bin/make -C '/home/vagrant/.phpbrew/build/php-5.4.34/ext/apc' 'install'  >> '/home/vagrant/.phpbrew/build/php-5.4.34/ext/apc/build.log' 2>&1
==> default: ===> Extension is installed.
==> default: ===> Creating config file /home/vagrant/.phpbrew/php/php-5.4.34/var/db/apc.ini.disabled
==> default: ===> Enabling extension apc
==> default: [*] apc extension is enabled.
==> default: Done.
==> default: update project dependencies
==> default: Downloading...
==> default: 
==> default: Composer (version 1.3.1) successfully installed to: /home/vagrant/project/integration-tests/composer.phar
==> default: Use it: php composer.phar
==> default: Some settings on your machine may cause stability issues with Composer.
==> default: If you encounter issues, try to change the following:
==> default: 
==> default: The apc.enable_cli setting is incorrect.
==> default: Add the following to the end of your `php.ini`:
==> default:     apc.enable_cli = Off
==> default: 
==> default: The php.ini used by your command-line PHP is: /home/vagrant/.phpbrew/php/php-5.4.34/etc/php.ini
==> default: If you can not modify the ini file, you can also run `php -d option=value` to modify ini values on the fly. You can use -d multiple times.
==> default: Loading composer repositories with package information
==> default: Updating dependencies (including require-dev)
==> default: Package operations: 18 installs, 0 updates, 0 removals
==> default:   - Installing psr/log (1.0.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing monolog/monolog (1.22.0)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing predis/predis (v1.0.4)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing symfony/yaml (v2.8.16)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/version (1.0.6)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/recursion-context (1.0.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/exporter (1.2.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/environment (1.3.8)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/diff (1.4.1)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing sebastian/comparator (1.2.2)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing doctrine/instantiator (1.0.5)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-text-template (1.2.1)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/phpunit-mock-objects (2.3.8)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-timer (1.0.8)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-file-iterator (1.3.4)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-token-stream (1.4.9)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/php-code-coverage (2.2.4)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default:   - Installing phpunit/phpunit (4.3.5)
==> default:  Downloading: Connecting...
==> default: 
==> default:  Downloading: 0%
==> default:            
==> default: 
==> default: 
==> default:  Downloading: 5%
==> default: 
==> default:  Downloading: 10%
==> default: 
==> default:  Downloading: 15%
==> default: 
==> default:  Downloading: 20%
==> default: 
==> default:  Downloading: 25%
==> default: 
==> default:  Downloading: 30%
==> default: 
==> default:  Downloading: 35%
==> default: 
==> default:  Downloading: 40%
==> default: 
==> default:  Downloading: 45%
==> default: 
==> default:  Downloading: 50%
==> default: 
==> default:  Downloading: 55%
==> default: 
==> default:  Downloading: 60%
==> default: 
==> default:  Downloading: 65%
==> default: 
==> default:  Downloading: 70%
==> default: 
==> default:  Downloading: 75%
==> default: 
==> default:  Downloading: 80%
==> default: 
==> default:  Downloading: 85%
==> default: 
==> default:  Downloading: 90%
==> default: 
==> default:  Downloading: 95%
==> default: 
==> default:  Downloading: 100%
==> default: monolog/monolog suggests installing aws/aws-sdk-php (Allow sending log messages to AWS services like DynamoDB)
==> default: monolog/monolog suggests installing doctrine/couchdb (Allow sending log messages to a CouchDB server)
==> default: monolog/monolog suggests installing ext-amqp (Allow sending log messages to an AMQP server (1.0+ required))
==> default: monolog/monolog suggests installing ext-mongo (Allow sending log messages to a MongoDB server)
==> default: monolog/monolog suggests installing graylog2/gelf-php (Allow sending log messages to a GrayLog2 server)
==> default: monolog/monolog suggests installing mongodb/mongodb (Allow sending log messages to a MongoDB server via PHP Driver)
==> default: monolog/monolog suggests installing php-amqplib/php-amqplib (Allow sending log messages to an AMQP server using php-amqplib)
==> default: monolog/monolog suggests installing php-console/php-console (Allow sending log messages to Google Chrome)
==> default: monolog/monolog suggests installing rollbar/rollbar (Allow sending log messages to Rollbar)
==> default: monolog/monolog suggests installing ruflin/elastica (Allow sending log messages to an Elastic Search server)
==> default: monolog/monolog suggests installing sentry/sentry (Allow sending log messages to a Sentry server)
==> default: predis/predis suggests installing ext-phpiredis (Allows faster serialization and deserialization of the Redis protocol)
==> default: predis/predis suggests installing ext-curl (Allows access to Webdis when paired with phpiredis)
==> default: phpunit/phpunit-mock-objects suggests installing ext-soap (*)
==> default: phpunit/php-code-coverage suggests installing ext-xdebug (>=2.2.1)
==> default: phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
==> default: Writing lock file
==> default: Generating autoload files
Welcome to Ubuntu 14.04.5 LTS (GNU/Linux 3.13.0-105-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Tue Jan 17 16:24:38 UTC 2017

  System load:  0.66              Processes:           82
  Usage of /:   3.6% of 39.34GB   Users logged in:     0
  Memory usage: 6%                IP address for eth0: 10.0.2.15
  Swap usage:   0%

  Graph this data and manage this system at:
    https://landscape.canonical.com/

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

0 packages can be updated.
0 updates are security updates.

New release '16.04.1 LTS' available.
Run 'do-release-upgrade' to upgrade to it.


vagrant@vagrant-ubuntu-trusty-64:~$ cd project/integration-tests/
vagrant@vagrant-ubuntu-trusty-64:~/project/integration-tests$ vendor/bin/phpunit LDDFeatureRequesterTest.php 
PHPUnit 4.3.5 by Sebastian Bergmann.

[2017-01-17 16:43:28] LaunchDarkly.WARNING: LDDFeatureRequester: Attempted to get missing feature with key: foo [] []
.[2017-01-17 16:43:29] LaunchDarkly.WARNING: LDDFeatureRequester: Attempted to get missing feature with key: foo [] []
.

Time: 329 ms, Memory: 4.50MB

OK (2 tests, 6 assertions)
```
