### PR TITLE
fix prerequisite decode notice

### DIFF
--- a/src/LaunchDarkly/FeatureFlag.php
+++ b/src/LaunchDarkly/FeatureFlag.php
@@ -57,7 +57,7 @@ class FeatureFlag {
                 $v['key'],
                 $v['version'],
                 $v['on'],
-                array_map(Prerequisite::getDecoder(), $v['prerequisites']),
+                array_map(Prerequisite::getDecoder(), $v['prerequisites'] ?: []),
                 $v['salt'],
                 array_map(Target::getDecoder(), $v['targets']),
                 array_map(Rule::getDecoder(), $v['rules']),

--- a/tests/FeatureFlagTest.php
+++ b/tests/FeatureFlagTest.php
@@ -140,5 +140,52 @@ class FeatureFlagTest extends \PHPUnit_Framework_TestCase {
         FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json1, true));
         FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json2, true));
     }
+    
+    public function dataDecodeMulti()
+    {
+        return [
+            'null-prerequisites' => [
+                [
+                    'key' => 'sysops-test',
+                    'version' => 14,
+                    'on' => true,
+                    'prerequisites' => NULL,
+                    'salt' => 'c3lzb3BzLXRlc3Q=',
+                    'sel' => '8ed13de1bfb14507ba7e6dde01f3e035',
+                    'targets' => [
+                        [
+                            'values' => [],
+                            'variation' => 0,
+                        ],
+                        [
+                            'values' => [],
+                            'variation' => 1,
+                        ],
+                    ],
+                    'rules' => [],
+                    'fallthrough' => [
+                        'variation' => 0,
+                    ],
+                    'offVariation' => NULL,
+                    'variations' => [
+                        true,
+                        false,
+                    ],
+                    'deleted' => false,
+                ]
+            ],
+        ];
+    }
+    
+    /**
+     * @dataProvider dataDecodeMulti
+     * @param array $feature
+     */
+    public function testDecodeMulti(array $feature)
+    {
+        $featureFlag = FeatureFlag::decode($feature);
+        
+        self::assertInstanceOf(FeatureFlag::class, $featureFlag);
+    }
 }
 


### PR DESCRIPTION
fix `WARNING: array_map(): Argument #2 should be an array in vendor/launchdarkly/launchdarkly-php/src/LaunchDarkly/FeatureFlag.php on line 60` where FeatureFlag assumes `prerequisites` will always be an array. in an ld-relay test i see that `prerequisites` can be null so that must be handled here.

here are some values stored in Redis by `ld-relay` from our dev account:
```
127.0.0.1:6379> hgetall launchdarkly:features
1) "pendo-snippet"
2) "{\"key\":\"pendo-snippet\",\"version\":2,\"on\":true,\"prerequisites\":[],\"salt\":\"cGVuZG8tc25pcHBldA==\",\"sel\":\"7bafff9319d84fd7bfaf056cfa9d08f9\",\"targets\":[{\"values\":[],\"variation\":0},{\"values\":[],\"variation\":1}],\"rules\":[],\"fallthrough\":{\"variation\":0},\"offVariation\":null,\"variations\":[true,false],\"deleted\":false}"
3) "sysops-test"
4) "{\"key\":\"sysops-test\",\"version\":16,\"on\":true,\"prerequisites\":null,\"salt\":\"c3lzb3BzLXRlc3Q=\",\"sel\":\"8ed13de1bfb14507ba7e6dde01f3e035\",\"targets\":[{\"values\":[],\"variation\":0},{\"values\":[],\"variation\":1}],\"rules\":[],\"fallthrough\":{\"variation\":0},\"offVariation\":null,\"variations\":[true,false],\"deleted\":false}"
5) "interop-outbound-doc-config"
6) "{\"key\":\"interop-outbound-doc-config\",\"version\":34,\"on\":true,\"prerequisites\":[],\"salt\":\"aW50ZXJvcC1vdXRib3VuZC1kb2MtY29uZmln\",\"sel\":\"6abfe4da9e9f4683abc44af55dcd5135\",\"targets\":[{\"values\":[],\"variation\":0},{\"values\":[],\"variation\":1}],\"rules\":[],\"fallthrough\":{\"variation\":0},\"offVariation\":null,\"variations\":[true,false],\"deleted\":false}"
7) "sysops-test-2"
8) "{\"key\":\"sysops-test-2\",\"version\":2,\"on\":true,\"prerequisites\":[],\"salt\":\"c3lzb3BzLXRlc3QtMg==\",\"sel\":\"6691c759127743709742ddb983e00c15\",\"targets\":[{\"values\":[],\"variation\":0},{\"values\":[],\"variation\":1}],\"rules\":[],\"fallthrough\":{\"rollout\":{\"variations\":[{\"variation\":0,\"weight\":10000},{\"variation\":1,\"weight\":90000}]}},\"offVariation\":null,\"variations\":[true,false],\"deleted\":false}"
```

i'm not sure why only one of these features has a null prerequisites block, but it's there. so i've added a unit test to cover that scenario and a src change to handle it. 