### PR TITLE
allow Predis\Client to be overridden in LDDFeatureRequester

### DIFF
--- a/src/LaunchDarkly/LDDFeatureRequester.php
+++ b/src/LaunchDarkly/LDDFeatureRequester.php
@@ -12,6 +12,8 @@ class LDDFeatureRequester implements FeatureRequester {
     protected $_features_key;
     /** @var  LoggerInterface */
     private $_logger;
+    /** @var  ClientInterface */
+    private $_connection;
 
     function __construct($baseUri, $apiKey, $options) {
         $this->_baseUri = $baseUri;
@@ -32,18 +34,21 @@ class LDDFeatureRequester implements FeatureRequester {
         $this->_features_key = "$prefix:features";
         $this->_logger = $options['logger'];
 
+        if (isset($this->_options['predis_client']) && $this->_options['predis_client'] instanceof ClientInterface) {
+            $this->_connection = $this->_options['predis_client'];
+        }
     }
 
     /**
      * @return ClientInterface
      */
     protected function get_connection() {
-        if (isset($this->_options['predis_client']) && $this->_options['predis_client'] instanceof ClientInterface) {
-            return $this->_options['predis_client'];
+        if ($this->_connection instanceof ClientInterface) {
+            return $this->_connection;
         }
         
         /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
-        return new \Predis\Client(array(
+        return $this->_connection = new \Predis\Client(array(
                                       "scheme" => "tcp",
                                       "host" => $this->_options['redis_host'],
                                       "port" => $this->_options['redis_port']));

--- a/src/LaunchDarkly/LDDFeatureRequester.php
+++ b/src/LaunchDarkly/LDDFeatureRequester.php
@@ -2,6 +2,7 @@
 namespace LaunchDarkly;
 
 
+use Predis\ClientInterface;
 use Psr\Log\LoggerInterface;
 
 class LDDFeatureRequester implements FeatureRequester {
@@ -33,7 +34,14 @@ class LDDFeatureRequester implements FeatureRequester {
 
     }
 
+    /**
+     * @return ClientInterface
+     */
     protected function get_connection() {
+        if (isset($this->_options['predis_client']) && $this->_options['predis_client'] instanceof ClientInterface) {
+            return $this->_options['predis_client'];
+        }
+        
         /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
         return new \Predis\Client(array(
                                       "scheme" => "tcp",

--- a/tests/LDDFeatureRequesterTest.php
+++ b/tests/LDDFeatureRequesterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace LaunchDarkly\Tests;
+
+use LaunchDarkly\FeatureFlag;
+use LaunchDarkly\LDDFeatureRequester;
+use Predis\ClientInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class LDDFeatureRequesterTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $predisClient;
+    
+    /** @var LoggerInterface */
+    private $logger;
+    
+    protected function setUp()
+    {
+        parent::setUp();
+        
+        $this->logger = new NullLogger();
+        
+        $this->predisClient = $this->getMockBuilder(ClientInterface::class)
+            ->setMethods(['hget'])
+            ->getMockForAbstractClass();
+    }
+    
+    public function testGet()
+    {
+        $sut = new LDDFeatureRequester('example.com', 'MyApiKey', [
+            'logger' => $this->logger,
+            'predis_client' => $this->predisClient,
+        ]);
+        
+        $this->predisClient->method('hget')->with('launchdarkly:features', 'foo')
+            ->willReturn(json_encode([
+                'key' => 'foo',
+                'version' => 14,
+                'on' => true,
+                'prerequisites' => [],
+                'salt' => 'c3lzb3BzLXRlc3Q=',
+                'sel' => '8ed13de1bfb14507ba7e6dde01f3e035',
+                'targets' => [
+                    [
+                        'values' => [],
+                        'variation' => 0,
+                    ],
+                    [
+                        'values' => [],
+                        'variation' => 1,
+                    ],
+                ],
+                'rules' => [],
+                'fallthrough' => [
+                    'variation' => 0,
+                ],
+                'offVariation' => null,
+                'variations' => [
+                    true,
+                    false,
+                ],
+                'deleted' => false,
+            ]));
+        
+        $featureFlag = $sut->get('foo');
+        
+        self::assertInstanceOf(FeatureFlag::class, $featureFlag);
+        self::assertTrue($featureFlag->isOn());
+    }
+}


### PR DESCRIPTION
allow Predis\Client to be overridden via parameter. this will allow consumers to factory their own Client with different Connection backends, Sentinel support, etc.