### PR TITLE
use `\Psr\Log\LoggerInterface::warning` instead of `\Monolog\Logger::warn` in `\LaunchDarkly\LDClient`

### DIFF
--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -24,7 +24,7 @@ class LDClient {
     protected $_send_events = true;
     /** @var array|mixed */
     protected $_defaults = array();
-    /** @var mixed|LoggerInterface */
+    /** @var LoggerInterface */
     protected $_logger;
 
     /** @var  FeatureRequester */
@@ -113,11 +113,11 @@ class LDClient {
         try {
             if (is_null($user) || is_null($user->getKey())) {
                 $this->_sendFlagRequestEvent($key, $user, $default, $default);
-                $this->_logger->warn("Variation called with null user or null user key! Returning default value");
+                $this->_logger->warning("Variation called with null user or null user key! Returning default value");
                 return $default;
             }
             if ($user->isKeyBlank()) {
-                $this->_logger->warn("User key is blank. Flag evaluation will proceed, but the user will not be stored in LaunchDarkly.");
+                $this->_logger->warning("User key is blank. Flag evaluation will proceed, but the user will not be stored in LaunchDarkly.");
             }
             $flag = $this->_featureRequester->get($key);
 
@@ -178,7 +178,7 @@ class LDClient {
             return;
         }
         if (is_null($user) || $user->isKeyBlank()) {
-            $this->_logger->warn("Track called with null user or null/empty user key!");
+            $this->_logger->warning("Track called with null user or null/empty user key!");
         }
 
         $event = array();
@@ -200,7 +200,7 @@ class LDClient {
             return;
         }
         if (is_null($user) || $user->isKeyBlank()) {
-            $this->_logger->warn("Track called with null user or null/empty user key!");
+            $this->_logger->warning("Track called with null user or null/empty user key!");
         }
 
         $event = array();

--- a/tests/LDClientTest.php
+++ b/tests/LDClientTest.php
@@ -6,6 +6,7 @@ use LaunchDarkly\FeatureRequester;
 use LaunchDarkly\LDClient;
 use LaunchDarkly\LDUser;
 use LaunchDarkly\LDUserBuilder;
+use Psr\Log\LoggerInterface;
 
 
 class LDClientTest extends \PHPUnit_Framework_TestCase {
@@ -63,6 +64,22 @@ class LDClientTest extends \PHPUnit_Framework_TestCase {
         $client = new LDClient("secret", ['offline' => true]);
         $user = new LDUser("Message");
         $this->assertEquals("aa747c502a898200f9e4fa21bac68136f886a0e27aec70ba06daf2e2a5cb5597",  $client->secureModeHash($user));
+    }
+    
+    public function testLoggerInterfaceWarn()
+    {
+        // Use LoggerInterface impl, instead of concreate Logger from Monolog, to demonstrate the problem with `warn`.
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        
+        $logger->expects(self::atLeastOnce())->method('warning');
+        
+        $client = new LDClient('secret', [
+            'logger' => $logger,
+        ]);
+    
+        $user = new LDUser('');
+        
+        $client->variation('MyFeature', $user);
     }
 }
 


### PR DESCRIPTION
`warn` is a method on the concrete Logger impl from Monolog. `warning` on the PSR LoggerInterface should be used instead.

without this change, or something like it, applications which use a logger other than Monolog are forced to write Launch Darkly factory code like this:

```
$options['logger'] = new Logger('LaunchDarkly', [
    new NullHandler(),
]);
return new LDClient($apiKey, $options);
```