### PR TITLE
Default was type hinted as boolean but can be anything.

### DIFF
--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -99,7 +99,7 @@ class LDClient {
      *
      * @param string $key The unique key for the feature flag
      * @param LDUser $user The end user requesting the flag
-     * @param boolean $default The default value of the flag
+     * @param mixed $default The default value of the flag
      *
      * @return mixed The result of the Feature Flag evaluation, or $default if any errors occurred.
      */


### PR DESCRIPTION
Feature flags can be anything when they are specified as multivariate.
Following this logic, the default value for a feature flag could be anything as wel.
Hinting on `boolean` here instead of `mixed` was a bit confusing.