### PR TITLE
Set target field to empty array whenever is null

### DIFF
--- a/src/LaunchDarkly/FeatureFlag.php
+++ b/src/LaunchDarkly/FeatureFlag.php
@@ -59,7 +59,7 @@ class FeatureFlag {
                 $v['on'],
                 array_map(Prerequisite::getDecoder(), $v['prerequisites'] ?: []),
                 $v['salt'],
-                array_map(Target::getDecoder(), $v['targets']),
+                array_map(Target::getDecoder(), $v['targets'] ?: []),
                 array_map(Rule::getDecoder(), $v['rules']),
                 call_user_func(VariationOrRollout::getDecoder(), $v['fallthrough']),
                 $v['offVariation'],


### PR DESCRIPTION
Fixing #74

Whenever the `target` field is null, should be setted as an empty array to satisfy the method signature.