### PR TITLE
Ensure that FeatureFlag _variations is non-null

### DIFF
--- a/src/LaunchDarkly/FeatureFlag.php
+++ b/src/LaunchDarkly/FeatureFlag.php
@@ -63,7 +63,7 @@ class FeatureFlag {
                 array_map(Rule::getDecoder(), $v['rules'] ?: []),
                 call_user_func(VariationOrRollout::getDecoder(), $v['fallthrough']),
                 $v['offVariation'],
-                $v['variations'],
+                $v['variations'] ?: [],
                 $v['deleted']);
         };
     }


### PR DESCRIPTION
Add a guard to FeatureFlag in case `$v['variations']` happens to be null.
