### PR TITLE
allow curl to be overridden.

### DIFF
--- a/src/LaunchDarkly/EventProcessor.php
+++ b/src/LaunchDarkly/EventProcessor.php
@@ -13,6 +13,7 @@ class EventProcessor {
   private $_host;
   private $_port;
   private $_ssl;
+  private $_curl = '/usr/bin/env curl';
 
   public function __construct($apiKey, $options = array()) {
     $this->_sdkKey = $apiKey;
@@ -38,6 +39,10 @@ class EventProcessor {
         else {
           $this->_path = '';
         }
+    }
+    
+    if (array_key_exists('curl', $options)) {
+        $this->_curl = $options['curl'];
     }
 
     $this->_capacity = $options['capacity'];
@@ -89,7 +94,7 @@ class EventProcessor {
   }
 
   private function makeRequest($args) {
-    $cmd = "/usr/bin/env curl " . $args . ">> /dev/null 2>&1 &";
+    $cmd = $this->_curl . " " . $args . ">> /dev/null 2>&1 &";
     shell_exec($cmd);
     return true;
   }


### PR DESCRIPTION
hi Team,

my org ran into an issue with shell/exec duplicating connections (e.g. to db/cache) because of PHP's Apache module fork implementation which duplicates file descriptors.

here's an old bug report (from 2003) which is unlikely to be resolved:
https://bugs.php.net/bug.php?id=15529

it will likely be useful to us if we can override curl, without messing with system env. i thought this request might be useful to others as well.