### PR TITLE
Public access to flush method

### DIFF
--- a/src/LaunchDarkly/EventProcessor.php
+++ b/src/LaunchDarkly/EventProcessor.php
@@ -17,7 +17,7 @@ class EventProcessor {
     $this->_capacity = $options['capacity'];
     $this->_timeout = $options['timeout'];
 
-    $this->_queue = array(); 
+    $this->_queue = array();
   }
 
   public function __destruct() {
@@ -38,7 +38,11 @@ class EventProcessor {
     return true;
   }
 
-  protected function flush() {
+  /**
+   * Publish events to LaunchDarkly
+   * @return bool Whether the events were successfully published
+   */
+  public function flush() {
     if (empty($this->_queue)) {
       return null;
     }

--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -95,7 +95,7 @@ class LDClient {
 
         $this->_featureRequester = $this->getFeatureRequester($sdkKey, $options);
     }
-    
+
     /**
      * @param string $sdkKey
      * @param mixed[] $options
@@ -106,7 +106,7 @@ class LDClient {
         if (isset($options['feature_requester']) && $options['feature_requester'] instanceof FeatureRequester) {
             return $options['feature_requester'];
         }
-        
+
         if (isset($options['feature_requester_class'])) {
             $featureRequesterClass = $options['feature_requester_class'];
         } else {
@@ -277,6 +277,16 @@ class LDClient {
             return "";
         }
         return hash_hmac("sha256", $user->getKey(), $this->_sdkKey, false);
+    }
+
+    /**
+     * Publish events to LaunchDarkly
+     * @param $payload string Event payload
+     * @return bool Whether the events were successfully published
+     */
+    public function flush()
+    {
+        return $this->_eventProcessor->flush();
     }
 
     /**

--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -281,7 +281,6 @@ class LDClient {
 
     /**
      * Publish events to LaunchDarkly
-     * @param $payload string Event payload
      * @return bool Whether the events were successfully published
      */
     public function flush()


### PR DESCRIPTION
I integrated this package using a Service Provider with Laravel, but the events are never sent when using the `track()` or `identify()` method, as the EventPublisher is never destroyed (as it is kept in the Service Container for further usage).

Allowing access to the `flush()` method via the LDClient will allow manual trigger of event publication. 