### PR TITLE
Fix class of LDClient::__construct cache option

### DIFF
--- a/src/LaunchDarkly/LDClient.php
+++ b/src/LaunchDarkly/LDClient.php
@@ -41,7 +41,7 @@ class LDClient {
      *     - events_uri: Base URI for sending events to LaunchDarkly. Defaults to 'https://events.launchdarkly.com'
      *     - timeout: Float describing the maximum length of a request in seconds. Defaults to 3
      *     - connect_timeout: Float describing the number of seconds to wait while trying to connect to a server. Defaults to 3
-     *     - cache: An optional Kevinrob\GuzzleCache\Strategy\CacheStorageInterface. Defaults to an in-memory cache.
+     *     - cache: An optional Kevinrob\GuzzleCache\Storage\CacheStorageInterface. Defaults to an in-memory cache.
      *     - send_events: An optional bool that can disable the sending of events to LaunchDarkly. Defaults to false.
      *     - logger: An optional Psr\Log\LoggerInterface. Defaults to a Monolog\Logger sending all messages to the php error_log.
      *     - offline: An optional boolean which will disable all network calls and always return the default value. Defaults to false.


### PR DESCRIPTION
As per this https://github.com/Kevinrob/guzzle-cache-middleware/blob/v1.5.2/src/Strategy/PublicCacheStrategy.php#L6
the proper class is `Kevinrob\GuzzleCache\Storage\CacheStorageInterface`