### PR TITLE
Allow bucketing attributes to be integers

### DIFF
--- a/src/LaunchDarkly/VariationOrRollout.php
+++ b/src/LaunchDarkly/VariationOrRollout.php
@@ -72,6 +72,9 @@ class VariationOrRollout {
         $userValue = $user->getValueForEvaluation($attr);
         $idHash = null;
         if ($userValue != null) {
+            if (is_int($userValue)) {
+                $userValue = (string)$userValue;
+            }
             if (is_string($userValue)) {
                 $idHash = $userValue;
                 if ($user->getSecondary() !== null) {

--- a/src/LaunchDarkly/VariationOrRollout.php
+++ b/src/LaunchDarkly/VariationOrRollout.php
@@ -73,7 +73,7 @@ class VariationOrRollout {
         $idHash = null;
         if ($userValue != null) {
             if (is_int($userValue)) {
-                $userValue = (string)$userValue;
+                $userValue = (string) $userValue;
             }
             if (is_string($userValue)) {
                 $idHash = $userValue;


### PR DESCRIPTION
When we bucket for rollouts, we do so by passing the account id associated with the user, which is an integer. Without the ability to pass the bucketing attribute as an integer, we must always cast the int to a string, which is cumbersome and may also cause broader issues because if passed as an int or anything that is not a string, it just gets ignored.

I also wanted to suggest that this be applied to all SDK's for consistency.