### PR TITLE
Fix: Use actual namespace for autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "": "tests/"
+            "LaunchDarkly\\Tests\\": "tests/"
         }
     }
 }


### PR DESCRIPTION
This PR

* [x] uses the actual `LaunchDarkly\Tests` namespace for the `autoload-dev` configuration

💁‍♂️ This is the namespace in which all of the tests in `tests/` reside.