### PR TITLE
Fix: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         }
     ],
     "require": {
-        "monolog/monolog": "^1.6",
         "php": ">=5.5",
+        "monolog/monolog": "^1.6",
         "psr/log": "^1.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.2.1",
         "kevinrob/guzzle-cache-middleware": "^1.4.1",
-        "phpunit/phpunit": ">=4.8.26 <5.4",
         "phpdocumentor/phpdocumentor": "^2.0",
+        "phpunit/phpunit": ">=4.8.26 <5.4",
         "predis/predis": "^1.0",
         "zendframework/zend-serializer": "^2.7"
     },
@@ -40,5 +40,8 @@
         "psr-4": {
             "": "tests/"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
This PR

* [x] keeps packages in `composer.json` sorted

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.