### PR TITLE
Fix: Case mismatch in method call

### DIFF
--- a/src/LaunchDarkly/Util.php
+++ b/src/LaunchDarkly/Util.php
@@ -14,7 +14,7 @@ class Util
      */
     public static function dateTimeToUnixMillis($dateTime)
     {
-        $timeStampSeconds = (int)$dateTime->getTimeStamp();
+        $timeStampSeconds = (int)$dateTime->getTimestamp();
         $timestampMicros = $dateTime->format('u');
         return $timeStampSeconds * 1000 + (int)($timestampMicros / 1000);
     }


### PR DESCRIPTION
This PR

* [x] fixes a case mismatch in a method call

💁‍♂️ For reference, see http://php.net/manual/en/datetime.gettimestamp.php.