### PR TITLE
Fix: Move argument to method call

### DIFF
--- a/src/LaunchDarkly/GuzzleFeatureRequester.php
+++ b/src/LaunchDarkly/GuzzleFeatureRequester.php
@@ -29,7 +29,7 @@ class GuzzleFeatureRequester implements FeatureRequester
         $this->_logger = $options['logger'];
         $stack = HandlerStack::create();
         if (class_exists('Kevinrob\GuzzleCache\CacheMiddleware')) {
-            $stack->push(new CacheMiddleware(new PublicCacheStrategy(isset($options['cache']) ? $options['cache'] : null), 'cache'));
+            $stack->push(new CacheMiddleware(new PublicCacheStrategy(isset($options['cache']) ? $options['cache'] : null)), 'cache');
         } elseif (!$this->_loggedCacheNotice) {
             $this->_logger->info("GuzzleFeatureRequester is not using an HTTP cache because Kevinrob\GuzzleCache\CacheMiddleware was not installed");
             $this->_loggedCacheNotice = true;


### PR DESCRIPTION
This PR

* [x] moves an otherwise unused constructor argument to a method call