### PR TITLE
Enhancement: Reference phpunit schema as installed with composer

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
     bootstrap="vendor/autoload.php"
 >
     <testsuites>
-        <testsuite>
+        <testsuite name="Unit Tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,8 @@
-<phpunit bootstrap="vendor/autoload.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+>
     <testsuites>
         <testsuite>
             <directory>tests</directory>


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` as installed with `composer`
* [x] adds a missing `name` attribute

💁‍♂️ The advantage of referencing the schema is auto-completion in IDEs, and also pointing out inconsistencies with the underlying schema. Referencing the schema installed with `composer` has the advantage that there is no need to hard-code the reference to a specific version.