### PR TITLE
Fix: Risky tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
+    colors="true"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutResourceUsageDuringSmallTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    verbose="true"
 >
     <testsuites>
         <testsuite name="Unit Tests">

--- a/tests/FeatureFlagTest.php
+++ b/tests/FeatureFlagTest.php
@@ -142,8 +142,8 @@ class FeatureFlagTest extends \PHPUnit_Framework_TestCase
 
     public function testDecode()
     {
-        FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json1, true));
-        FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json2, true));
+        $this->assertInstanceOf(FeatureFlag::class, FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json1, true)));
+        $this->assertInstanceOf(FeatureFlag::class, FeatureFlag::decode(\GuzzleHttp\json_decode(FeatureFlagTest::$json2, true)));
     }
     
     public function dataDecodeMulti()

--- a/tests/LDClientTest.php
+++ b/tests/LDClientTest.php
@@ -14,7 +14,7 @@ class LDClientTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultCtor()
     {
-        new LDClient("BOGUS_SDK_KEY");
+        $this->assertInstanceOf(LDClient::class, new LDClient("BOGUS_SDK_KEY"));
     }
 
     public function testToggleDefault()

--- a/tests/LDUserTest.php
+++ b/tests/LDUserTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace LaunchDarkly\Tests;
 
+use LaunchDarkly\LDUser;
 use LaunchDarkly\LDUserBuilder;
 
 class LDUserTest extends \PHPUnit_Framework_TestCase
@@ -23,7 +24,10 @@ class LDUserTest extends \PHPUnit_Framework_TestCase
     public function testEmptyCustom()
     {        
         $builder = new LDUserBuilder("foo@bar.com");
+        
         $user = $builder->build();
+        
+        $this->assertInstanceOf(LDUser::class, $user);
     }
 
     public function testLDUserSecondary()

--- a/tests/SemanticVersionTest.php
+++ b/tests/SemanticVersionTest.php
@@ -47,32 +47,31 @@ class SemanticVersionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('build2.4', $sv->build);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage not a valid semantic version
+     */
     public function testLeadingZeroNotAllowedInMajor()
     {
-        try {
-            SemanticVersion::parse('02.3.4');
-            $this->assertTrue(false, 'expected exception');
-            // can't use expectException method because we must support older PHPUnit
-        } catch (\InvalidArgumentException $e) {
-        }
+        SemanticVersion::parse('02.3.4');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage not a valid semantic version
+     */
     public function testLeadingZeroNotAllowedInMinor()
     {
-        try {
-            SemanticVersion::parse('2.03.4');
-            $this->assertTrue(false, 'expected exception');
-        } catch (\InvalidArgumentException $e) {
-        }
+        SemanticVersion::parse('2.03.4');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage not a valid semantic version
+     */
     public function testLeadingZeroNotAllowedInPatch()
     {
-        try {
-            SemanticVersion::parse('2.3.04');
-            $this->assertTrue(false, 'expected exception');
-        } catch (\InvalidArgumentException $e) {
-        }
+        SemanticVersion::parse('2.3.04');
     }
 
     public function testZeroByItselfIsAllowed()
@@ -147,22 +146,22 @@ class SemanticVersionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('build1', $sv->build);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage not a valid semantic version
+     */
     public function testCannotParseVersionWithMajorOnlyByDefault()
     {
-        try {
-            SemanticVersion::parse('2');
-            $this->assertTrue(false, 'expected exception');
-        } catch (\InvalidArgumentException $e) {
-        }
+        SemanticVersion::parse('2');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage not a valid semantic version
+     */
     public function testCannotParseVersionWithMajorAndMinorOnlyByDefault()
     {
-        try {
-            SemanticVersion::parse('2.3');
-            $this->assertTrue(false, 'expected exception');
-        } catch (\InvalidArgumentException $e) {
-        }
+        SemanticVersion::parse('2.3');
     }
 
     public function testEqualVersionsHaveEqualPrecedence()


### PR DESCRIPTION
This PR

* [x] tweaks the PHPUnit configuration to expose risky tests
* [x] fixes risky tests

### Before

![screen shot 2018-05-24 at 22 05 27](https://user-images.githubusercontent.com/605483/40511887-6a971d6e-5fa1-11e8-9c91-ae67af78a527.png)

### During

![screen shot 2018-05-24 at 22 09 31](https://user-images.githubusercontent.com/605483/40511905-735409ee-5fa1-11e8-8591-7f8fed018bb4.png)

### After

![screen shot 2018-05-24 at 22 29 16](https://user-images.githubusercontent.com/605483/40512090-03546408-5fa2-11e8-89ad-9888cd15ed9a.png)
