### PR TITLE
Update spelling of anonymous property of LDUser

### DIFF
--- a/src/LaunchDarkly/LDUser.php
+++ b/src/LaunchDarkly/LDUser.php
@@ -17,7 +17,7 @@ class LDUser
     protected $_avatar = null;
     protected $_firstName = null;
     protected $_lastName = null;
-    protected $_anonyomus = false;
+    protected $_anonymous = false;
     protected $_custom = array();
     protected $_privateAttributeNames = array();
 


### PR DESCRIPTION
The protected $anonyomus field results in a public $anonymous field being added whenever someone builds an LDUser that is anonymous. Fixing the spelling will bring that back to protected.